### PR TITLE
Add Seedance 2.0 text-to-video model

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,14 @@ The Video Studio follows the same pattern:
 
 | Mode | Trigger | Models | Prompt |
 | :--- | :--- | :--- | :--- |
-| **Text-to-Video** | Default (no image) | 40+ t2v models (Kling, Sora, Veo, Wan, Seedance, Hailuo, Runway…) | Required |
+| **Text-to-Video** | Default (no image) | 40+ t2v models (Kling, Sora, Veo, Wan, Seedance 2.0, Hailuo, Runway…) | Required |
 | **Image-to-Video** | Start frame uploaded | 60+ i2v models (Kling I2V, Veo3 I2V, Runway I2V, Wan I2V, Midjourney I2V…) | Optional |
+
+#### Newly Added Models
+
+| Model | Type | Key Features |
+| :--- | :--- | :--- |
+| **Seedance 2.0** | Text-to-Video | ByteDance · Aspect ratios 16:9 / 9:16 / 4:3 / 3:4 · Duration 5 / 10 / 15s · Quality basic/high |
 
 ### 🎥 Cinema Studio Controls
 
@@ -178,7 +184,7 @@ File uploads use `POST /api/v1/upload_file` (multipart/form-data) and return a h
 |---|---|---|
 | **Text-to-Image** | 50+ | Flux Dev, Nano Banana 2, Seedream 5.0, Ideogram v3, Midjourney v7, GPT-4o, SDXL |
 | **Image-to-Image** | 55+ | Nano Banana 2 Edit (×14), Flux Kontext Pro, GPT-4o Edit, Seededit v3, Upscaler, Background Remover |
-| **Text-to-Video** | 40+ | Kling v3, Sora 2, Veo 3, Wan 2.6, Seedance Pro, Hailuo 2.3, Runway Gen-3 |
+| **Text-to-Video** | 40+ | Kling v3, Sora 2, Veo 3, Wan 2.6, Seedance 2.0, Seedance Pro, Hailuo 2.3, Runway Gen-3 |
 | **Image-to-Video** | 60+ | Kling v2.1 I2V, Veo3 I2V, Runway I2V, Midjourney v7 I2V, Hunyuan I2V, Wan2.2 I2V |
 
 ## 🛠️ Tech Stack

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -2161,6 +2161,16 @@ export const t2vModels = [
     }
   },
   {
+    "id": "seedance-v2.0-t2v",
+    "name": "Seedance 2.0",
+    "inputs": {
+      "prompt": { "type": "string", "title": "Prompt", "name": "prompt", "description": "The prompt to generate the video" },
+      "aspect_ratio": { "enum": ["16:9", "9:16", "4:3", "3:4"], "title": "Aspect Ratio", "name": "aspect_ratio", "type": "string", "description": "Aspect ratio of the output video.", "default": "16:9" },
+      "duration": { "enum": [5, 10, 15], "title": "Duration", "name": "duration", "type": "int", "description": "The duration of the generated video in seconds", "default": 5 },
+      "quality": { "enum": ["high", "basic"], "title": "Quality", "name": "quality", "type": "string", "description": "Quality of the generated video.", "default": "basic" }
+    }
+  },
+  {
     "id": "kling-v2.1-master-t2v",
     "name": "Kling v2.1 Master",
     "inputs": {


### PR DESCRIPTION
Integrates ByteDance's Seedance v2.0 into Video Studio with support for aspect ratios (16:9, 9:16, 4:3, 3:4), durations (5/10/15s), and quality (basic/high). Updates README to reflect the new model.