### PR TITLE
Add 15s duration and all modes to Grok Imagine video models

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The Video Studio follows the same pattern:
 | **Seedance 2.0** | Text-to-Video | ByteDance · Aspect ratios 16:9 / 9:16 / 4:3 / 3:4 · Duration 5 / 10 / 15s · Quality basic/high |
 | **Seedance 2.0 I2V** | Image-to-Video | ByteDance · Animate images into video · Up to 9 reference images · Aspect ratios 16:9 / 9:16 / 4:3 / 3:4 · Duration 5 / 10 / 15s · Quality basic/high |
 | **Seedance 2.0 Extend** | Video Extension | ByteDance · Seamlessly continue any Seedance 2.0 generation · Preserves style, motion & audio · Optional continuation prompt · Duration 5 / 10 / 15s · Quality basic/high |
+| **Grok Imagine T2V** | Text-to-Video | xAI · Duration 6 / 10 / **15s** · Modes: fun / normal / spicy · Aspect ratios 9:16 / 16:9 / 2:3 / 3:2 / 1:1 |
+| **Grok Imagine I2V** | Image-to-Video | xAI · Duration 6 / 10 / **15s** · Modes: fun / normal / spicy · Cinematic motion from still images |
 
 ### 🎙️ Lip Sync Studio
 

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -2474,7 +2474,8 @@ export const t2vModels = [
     "inputs": {
       "prompt": { "type": "string", "title": "Prompt", "name": "prompt", "description": "Text prompt describing the video." },
       "aspect_ratio": { "enum": ["9:16", "16:9", "2:3", "3:2", "1:1"], "title": "Aspect Ratio", "name": "aspect_ratio", "type": "string", "description": "Aspect ratio of the output video.", "default": "1:1" },
-      "duration": { "enum": [6, 10], "title": "Duration", "name": "duration", "type": "int", "description": "The duration of the generated video in seconds.", "default": 6 }
+      "mode": { "enum": ["fun", "normal", "spicy"], "title": "Mode", "name": "mode", "type": "string", "description": "Generation style: normal = standard output; fun = more creative/expressive; spicy = edgier content (text-to-video only).", "default": "normal" },
+      "duration": { "enum": [6, 10, 15], "title": "Duration", "name": "duration", "type": "int", "description": "The duration of the generated video in seconds.", "default": 6 }
     }
   },
   {
@@ -7227,7 +7228,8 @@ export const i2vModels = [
         "description": "The duration of the generated video in seconds.",
         "enum": [
           6,
-          10
+          10,
+          15
         ],
         "default": 6
       }


### PR DESCRIPTION
- grok-imagine-text-to-video: duration [6, 10] → [6, 10, 15], add mode field (fun/normal/spicy)
- grok-imagine-image-to-video: duration [6, 10] → [6, 10, 15]
- Update README with Grok Imagine T2V and I2V entries