### PR TITLE
feat: add Novita provider integration

### DIFF
--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -1,4 +1,10 @@
+import { getActiveProvider, getProviderMeta, getProviderStorageKey } from '../lib/providerConfig.js';
+
 export function AuthModal(onSuccess) {
+    const provider = getActiveProvider();
+    const meta = getProviderMeta(provider);
+    const storageKey = getProviderStorageKey(provider);
+
     const overlay = document.createElement('div');
     overlay.className = 'fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm px-6';
 
@@ -12,17 +18,17 @@ export function AuthModal(onSuccess) {
                     <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3m-3-3l-2.25-2.25"/>
                 </svg>
             </div>
-            <h2 class="text-2xl font-black text-white uppercase tracking-wider mb-2">Muapi API Key Required</h2>
-            <p class="text-secondary text-sm">Please provide your Muapi.ai API key to start creating high-aesthetic images.</p>
+            <h2 class="text-2xl font-black text-white uppercase tracking-wider mb-2">${meta.name} API Key Required</h2>
+            <p class="text-secondary text-sm">Please provide your ${meta.name} API key to continue.</p>
         </div>
 
         <div class="space-y-6">
             <div class="space-y-2">
                 <label class="text-[10px] font-bold text-muted uppercase tracking-widest ml-1">Your API Key</label>
-                <input 
-                    type="password" 
-                    id="muapi-key-input"
-                    placeholder="Enter your Muapi API key..."
+                <input
+                    type="password"
+                    id="provider-key-input"
+                    placeholder="Enter your ${meta.name} API key..."
                     class="w-full bg-black/40 border border-white/5 rounded-2xl px-5 py-4 text-white placeholder:text-muted focus:outline-none focus:border-primary/50 transition-colors shadow-inner"
                 >
             </div>
@@ -31,8 +37,8 @@ export function AuthModal(onSuccess) {
                 <button id="save-key-btn" class="w-full bg-primary text-black font-black py-4 rounded-2xl hover:shadow-glow hover:scale-[1.02] active:scale-[0.98] transition-all">
                     Initialize Studio
                 </button>
-                <a href="https://muapi.ai" target="_blank" class="text-center text-[11px] font-bold text-muted hover:text-white transition-colors py-2 uppercase tracking-tighter">
-                    Get an API Key at Muapi.ai →
+                <a href="${meta.website}" target="_blank" class="text-center text-[11px] font-bold text-muted hover:text-white transition-colors py-2 uppercase tracking-tighter">
+                    Get an API Key at ${meta.name} →
                 </a>
             </div>
         </div>
@@ -41,13 +47,13 @@ export function AuthModal(onSuccess) {
     overlay.appendChild(modal);
     document.body.appendChild(overlay);
 
-    const input = modal.querySelector('#muapi-key-input');
+    const input = modal.querySelector('#provider-key-input');
     const btn = modal.querySelector('#save-key-btn');
 
     btn.onclick = () => {
         const key = input.value.trim();
         if (key) {
-            localStorage.setItem('muapi_key', key);
+            localStorage.setItem(storageKey, key);
             document.body.removeChild(overlay);
             if (onSuccess) onSuccess();
         } else {

--- a/src/components/CinemaStudio.js
+++ b/src/components/CinemaStudio.js
@@ -1,5 +1,6 @@
 
-import { muapi } from '../lib/muapi.js';
+import { api } from '../lib/providerRouter.js';
+import { getProviderApiKey } from '../lib/providerConfig.js';
 import { CameraControls } from './CameraControls.js';
 import { buildNanoBananaPrompt, CAMERA_MAP, LENS_MAP } from '../lib/promptUtils.js';
 import { AuthModal } from './AuthModal.js';
@@ -417,7 +418,7 @@ export function CinemaStudio() {
         const basePrompt = textarea.value.trim();
         if (!basePrompt) return;
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) {
             AuthModal(() => generateBtn.click());
             return;
@@ -436,7 +437,7 @@ export function CinemaStudio() {
         );
 
         try {
-            const res = await muapi.generateImage({
+            const res = await api.generateImage({
                 model: 'nano-banana-pro',
                 prompt: finalPrompt,
                 aspect_ratio: currentSettings.aspect_ratio,

--- a/src/components/ImageStudio.js
+++ b/src/components/ImageStudio.js
@@ -1,4 +1,5 @@
-import { muapi } from '../lib/muapi.js';
+import { api } from '../lib/providerRouter.js';
+import { getProviderApiKey } from '../lib/providerConfig.js';
 import {
     t2iModels, getAspectRatiosForModel, getResolutionsForModel, getQualityFieldForModel,
     i2iModels, getAspectRatiosForI2IModel, getResolutionsForI2IModel, getQualityFieldForI2IModel,
@@ -509,7 +510,7 @@ export function ImageStudio() {
         const pending = getPendingJobs('image');
         if (!pending.length) return;
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) return; // can't poll without key; jobs remain for next time
 
         const banner = document.createElement('div');
@@ -522,7 +523,7 @@ export function ImageStudio() {
             const elapsedAttempts = Math.floor((Date.now() - job.submittedAt) / job.interval);
             const attemptsLeft = Math.max(1, job.maxAttempts - elapsedAttempts);
             try {
-                const result = await muapi.pollForResult(job.requestId, apiKey, attemptsLeft, job.interval);
+                const result = await api.pollForResult(job.requestId, apiKey, attemptsLeft, job.interval);
                 const url = result.outputs?.[0] || result.url || result.output?.url;
                 if (url) {
                     addToHistory({ id: job.requestId, url, ...job.historyMeta, timestamp: new Date().toISOString() });
@@ -595,7 +596,7 @@ export function ImageStudio() {
             }
         }
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) {
             AuthModal(() => generateBtn.click());
             return;
@@ -626,7 +627,7 @@ export function ImageStudio() {
                 if (prompt) genParams.prompt = prompt;
                 const qualityField = getCurrentQualityField(selectedModel);
                 if (qualityField && qualityLabel) genParams[qualityField] = qualityLabel;
-                res = await muapi.generateI2I(genParams);
+                res = await api.generateI2I(genParams);
             } else {
                 const genParams = {
                     model: selectedModel,
@@ -639,7 +640,7 @@ export function ImageStudio() {
                 };
                 const qualityField = getCurrentQualityField(selectedModel);
                 if (qualityField && qualityLabel) genParams[qualityField] = qualityLabel;
-                res = await muapi.generateImage(genParams);
+                res = await api.generateImage(genParams);
             }
 
             console.log('[ImageStudio] Full response:', res);

--- a/src/components/LipSyncStudio.js
+++ b/src/components/LipSyncStudio.js
@@ -1,4 +1,5 @@
-import { muapi } from '../lib/muapi.js';
+import { api } from '../lib/providerRouter.js';
+import { getProviderApiKey } from '../lib/providerConfig.js';
 import { lipsyncModels, imageLipSyncModels, videoLipSyncModels, getLipSyncModelById, getResolutionsForLipSyncModel } from '../lib/models.js';
 import { AuthModal } from './AuthModal.js';
 import { createUploadPicker } from './UploadPicker.js';
@@ -168,11 +169,11 @@ export function LipSyncStudio() {
     videoFileInput.onchange = async (e) => {
         const file = e.target.files[0];
         if (!file) return;
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) { AuthModal(() => videoFileInput.click()); return; }
         showVideoSpinner();
         try {
-            uploadedVideoUrl = await muapi.uploadFile(file);
+            uploadedVideoUrl = await api.uploadFile(file);
             showVideoReady(file.name);
         } catch (err) { showVideoIcon(); alert(`Video upload failed: ${err.message}`); }
         videoFileInput.value = '';
@@ -236,11 +237,11 @@ export function LipSyncStudio() {
     audioFileInput.onchange = async (e) => {
         const file = e.target.files[0];
         if (!file) return;
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) { AuthModal(() => audioFileInput.click()); return; }
         showAudioSpinner();
         try {
-            uploadedAudioUrl = await muapi.uploadFile(file);
+            uploadedAudioUrl = await api.uploadFile(file);
             showAudioReady(file.name);
         } catch (err) { showAudioIcon(); alert(`Audio upload failed: ${err.message}`); }
         audioFileInput.value = '';
@@ -587,7 +588,7 @@ export function LipSyncStudio() {
     (async () => {
         const pending = getPendingJobs('lipsync');
         if (!pending.length) return;
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) return;
         const banner = document.createElement('div');
         banner.className = 'fixed top-4 left-1/2 -translate-x-1/2 z-[200] bg-[#111] border border-white/10 text-white text-sm px-5 py-3 rounded-2xl shadow-xl flex items-center gap-3';
@@ -598,7 +599,7 @@ export function LipSyncStudio() {
             const elapsedAttempts = Math.floor((Date.now() - job.submittedAt) / job.interval);
             const attemptsLeft = Math.max(1, job.maxAttempts - elapsedAttempts);
             try {
-                const result = await muapi.pollForResult(job.requestId, apiKey, attemptsLeft, job.interval);
+                const result = await api.pollForResult(job.requestId, apiKey, attemptsLeft, job.interval);
                 const url = result.outputs?.[0] || result.url || result.output?.url;
                 if (url) addToHistory({ id: job.requestId, url, ...job.historyMeta, timestamp: new Date().toISOString() });
             } catch (e) { console.warn('[LipSyncStudio] Pending job failed:', job.requestId, e.message); }
@@ -667,7 +668,7 @@ export function LipSyncStudio() {
             return;
         }
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) { AuthModal(() => generateBtn.click()); return; }
 
         hero.classList.add('opacity-0', 'scale-95', '-translate-y-10', 'pointer-events-none');
@@ -703,7 +704,7 @@ export function LipSyncStudio() {
 
             if (model?.hasSeed) lipsyncParams.seed = -1;
 
-            const res = await muapi.processLipSync(lipsyncParams);
+            const res = await api.processLipSync(lipsyncParams);
             console.log('[LipSyncStudio] Response:', res);
 
             if (res && res.url) {

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -1,47 +1,57 @@
+import { getActiveProvider, getProviders, getProviderApiKey, setActiveProvider } from '../lib/providerConfig.js';
+
 export function SettingsModal(onClose) {
     const overlay = document.createElement('div');
     overlay.className = 'fixed inset-0 bg-black/80 flex items-center justify-center z-50';
-    overlay.style.position = 'fixed';
-    overlay.style.top = '0';
-    overlay.style.left = '0';
-    overlay.style.right = '0';
-    overlay.style.bottom = '0';
-    overlay.style.backgroundColor = 'rgba(0,0,0,0.8)';
-    overlay.style.display = 'flex';
-    overlay.style.alignItems = 'center';
-    overlay.style.justifyContent = 'center';
-    overlay.style.zIndex = '100';
 
     const modal = document.createElement('div');
     modal.className = 'bg-card p-6 rounded-xl border border-border-color w-96 glass';
-    modal.style.background = 'var(--bg-card)';
-    modal.style.padding = '1.5rem';
-    modal.style.borderRadius = 'var(--border-radius-xl)';
-    modal.style.border = '1px solid var(--border-color)';
-    modal.style.width = '24rem';
 
     const title = document.createElement('h2');
     title.textContent = 'Settings';
     title.className = 'text-xl font-bold mb-4';
-    title.style.marginBottom = '1rem';
 
-    const label = document.createElement('label');
-    label.textContent = 'Muapi API Key';
-    label.className = 'block text-sm text-secondary mb-2';
+    const providerLabel = document.createElement('label');
+    providerLabel.textContent = 'Active Provider';
+    providerLabel.className = 'block text-sm text-secondary mb-2';
 
-    const input = document.createElement('input');
-    input.type = 'password';
-    input.className = 'w-full mb-4 p-2 rounded bg-input border border-border-color';
-    input.value = localStorage.getItem('muapi_key') || '';
-    input.placeholder = 'Enter your Muapi API key...';
-    input.style.width = '100%';
-    input.style.marginBottom = '1rem';
+    const providerSelect = document.createElement('select');
+    providerSelect.className = 'w-full mb-4 p-2 rounded bg-input border border-border-color';
+    const activeProvider = getActiveProvider();
+    getProviders().forEach((p) => {
+        const option = document.createElement('option');
+        option.value = p.id;
+        option.textContent = p.name;
+        if (p.id === activeProvider) option.selected = true;
+        providerSelect.appendChild(option);
+    });
+
+    const muapiLabel = document.createElement('label');
+    muapiLabel.textContent = 'Muapi API Key';
+    muapiLabel.className = 'block text-sm text-secondary mb-2';
+
+    const muapiInput = document.createElement('input');
+    muapiInput.type = 'password';
+    muapiInput.className = 'w-full mb-4 p-2 rounded bg-input border border-border-color';
+    muapiInput.value = getProviderApiKey('muapi');
+    muapiInput.placeholder = 'Enter your Muapi API key...';
+
+    const novitaLabel = document.createElement('label');
+    novitaLabel.textContent = 'Novita API Key';
+    novitaLabel.className = 'block text-sm text-secondary mb-2';
+
+    const novitaInput = document.createElement('input');
+    novitaInput.type = 'password';
+    novitaInput.className = 'w-full mb-4 p-2 rounded bg-input border border-border-color';
+    novitaInput.value = getProviderApiKey('novita');
+    novitaInput.placeholder = 'Enter your Novita API key...';
+
+    const help = document.createElement('p');
+    help.className = 'text-xs text-secondary mb-4';
+    help.textContent = 'Default provider is Muapi. Switching provider keeps both keys in local storage.';
 
     const btnContainer = document.createElement('div');
     btnContainer.className = 'flex justify-end gap-2';
-    btnContainer.style.display = 'flex';
-    btnContainer.style.justifyContent = 'flex-end';
-    btnContainer.style.gap = '0.5rem';
 
     const cancelBtn = document.createElement('button');
     cancelBtn.textContent = 'Cancel';
@@ -54,25 +64,35 @@ export function SettingsModal(onClose) {
     const saveBtn = document.createElement('button');
     saveBtn.textContent = 'Save';
     saveBtn.className = 'px-4 py-2 rounded bg-primary text-black font-medium';
-    saveBtn.style.backgroundColor = 'var(--color-primary)';
-    saveBtn.style.color = 'black';
-    saveBtn.style.fontWeight = '500';
 
     saveBtn.onclick = () => {
-        const key = input.value.trim();
-        if (key) {
-            localStorage.setItem('muapi_key', key);
-            alert('API Key saved!');
-            document.body.removeChild(overlay);
-            if (onClose) onClose();
-        } else {
-            alert('Please enter a valid key');
+        const selectedProvider = providerSelect.value;
+        const muapiKey = muapiInput.value.trim();
+        const novitaKey = novitaInput.value.trim();
+
+        if (muapiKey) localStorage.setItem('muapi_key', muapiKey);
+        if (novitaKey) localStorage.setItem('novita_api_key', novitaKey);
+
+        const selectedKey = selectedProvider === 'novita' ? novitaKey || localStorage.getItem('novita_api_key') : muapiKey || localStorage.getItem('muapi_key');
+        if (!selectedKey) {
+            alert(`Please enter a valid ${selectedProvider === 'novita' ? 'Novita' : 'Muapi'} API key.`);
+            return;
         }
+
+        setActiveProvider(selectedProvider);
+        alert('Settings saved!');
+        document.body.removeChild(overlay);
+        if (onClose) onClose();
     };
 
     modal.appendChild(title);
-    modal.appendChild(label);
-    modal.appendChild(input);
+    modal.appendChild(providerLabel);
+    modal.appendChild(providerSelect);
+    modal.appendChild(muapiLabel);
+    modal.appendChild(muapiInput);
+    modal.appendChild(novitaLabel);
+    modal.appendChild(novitaInput);
+    modal.appendChild(help);
 
     btnContainer.appendChild(cancelBtn);
     btnContainer.appendChild(saveBtn);
@@ -80,7 +100,6 @@ export function SettingsModal(onClose) {
 
     overlay.appendChild(modal);
 
-    // Close on outside click
     overlay.addEventListener('click', (e) => {
         if (e.target === overlay) {
             document.body.removeChild(overlay);

--- a/src/components/UploadPicker.js
+++ b/src/components/UploadPicker.js
@@ -1,4 +1,5 @@
-import { muapi } from '../lib/muapi.js';
+import { api } from '../lib/providerRouter.js';
+import { getProviderApiKey } from '../lib/providerConfig.js';
 import { AuthModal } from './AuthModal.js';
 import { getUploadHistory, saveUpload, removeUpload, generateThumbnail } from '../lib/uploadHistory.js';
 
@@ -318,7 +319,7 @@ export function createUploadPicker({ anchorContainer, onSelect, onClear, maxImag
         const files = Array.from(e.target.files);
         if (!files.length) return;
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) {
             AuthModal(() => fileInput.click());
             return;
@@ -331,7 +332,7 @@ export function createUploadPicker({ anchorContainer, onSelect, onClear, maxImag
                 // Single mode: upload first file only, replace selection
                 const file = files[0];
                 const [uploadedUrl, thumbnail] = await Promise.all([
-                    muapi.uploadFile(file),
+                    api.uploadFile(file),
                     generateThumbnail(file)
                 ]);
                 const entry = { id: Date.now().toString(), name: file.name, uploadedUrl, thumbnail, timestamp: new Date().toISOString() };
@@ -347,7 +348,7 @@ export function createUploadPicker({ anchorContainer, onSelect, onClear, maxImag
                 // Upload all in parallel
                 const results = await Promise.all(toUpload.map(async (file) => {
                     const [uploadedUrl, thumbnail] = await Promise.all([
-                        muapi.uploadFile(file),
+                        api.uploadFile(file),
                         generateThumbnail(file)
                     ]);
                     return { id: Date.now().toString() + Math.random(), name: file.name, uploadedUrl, thumbnail, timestamp: new Date().toISOString() };

--- a/src/components/VideoStudio.js
+++ b/src/components/VideoStudio.js
@@ -1,4 +1,5 @@
-import { muapi } from '../lib/muapi.js';
+import { api } from '../lib/providerRouter.js';
+import { getProviderApiKey } from '../lib/providerConfig.js';
 import { t2vModels, getAspectRatiosForVideoModel, getDurationsForModel, getResolutionsForVideoModel, i2vModels, getAspectRatiosForI2VModel, getDurationsForI2VModel, getResolutionsForI2VModel, v2vModels, getModesForModel } from '../lib/models.js';
 import { AuthModal } from './AuthModal.js';
 import { createUploadPicker } from './UploadPicker.js';
@@ -188,7 +189,7 @@ export function VideoStudio() {
         const file = e.target.files[0];
         if (!file) return;
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) {
             AuthModal(() => videoFileInput.click());
             return;
@@ -196,7 +197,7 @@ export function VideoStudio() {
 
         showVideoSpinner();
         try {
-            const url = await muapi.uploadFile(file);
+            const url = await api.uploadFile(file);
             uploadedVideoUrl = url;
             showVideoReady(file.name);
 
@@ -814,7 +815,7 @@ export function VideoStudio() {
         const pending = getPendingJobs('video');
         if (!pending.length) return;
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) return; // can't poll without key; jobs remain for next time
 
         const banner = document.createElement('div');
@@ -827,7 +828,7 @@ export function VideoStudio() {
             const elapsedAttempts = Math.floor((Date.now() - job.submittedAt) / job.interval);
             const attemptsLeft = Math.max(1, job.maxAttempts - elapsedAttempts);
             try {
-                const result = await muapi.pollForResult(job.requestId, apiKey, attemptsLeft, job.interval);
+                const result = await api.pollForResult(job.requestId, apiKey, attemptsLeft, job.interval);
                 const url = result.outputs?.[0] || result.url || result.output?.url;
                 if (url) {
                     addToHistory({ id: job.requestId, url, ...job.historyMeta, timestamp: new Date().toISOString() });
@@ -926,7 +927,7 @@ export function VideoStudio() {
             }
         }
 
-        const apiKey = localStorage.getItem('muapi_key');
+        const apiKey = getProviderApiKey();
         if (!apiKey) {
             AuthModal(() => generateBtn.click());
             return;
@@ -947,7 +948,7 @@ export function VideoStudio() {
 
         try {
             if (v2vMode) {
-                const res = await muapi.processV2V({ model: selectedModel, video_url: uploadedVideoUrl, onRequestId });
+                const res = await api.processV2V({ model: selectedModel, video_url: uploadedVideoUrl, onRequestId });
                 console.log('[VideoStudio] V2V response:', res);
                 if (res && res.url) {
                     if (capturedRequestId) removePendingJob(capturedRequestId);
@@ -979,7 +980,7 @@ export function VideoStudio() {
                 if (selectedQuality) i2vParams.quality = selectedQuality;
                 if (selectedMode) i2vParams.mode = selectedMode;
 
-                const res = await muapi.generateI2V(i2vParams);
+                const res = await api.generateI2V(i2vParams);
                 console.log('[VideoStudio] I2V response:', res);
 
                 if (res && res.url) {
@@ -1022,7 +1023,7 @@ export function VideoStudio() {
             if (selectedQuality) params.quality = selectedQuality;
             if (selectedMode) params.mode = selectedMode;
 
-            const res = await muapi.generateVideo(params);
+            const res = await api.generateVideo(params);
 
             console.log('[VideoStudio] Full response:', res);
 

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -8169,3 +8169,105 @@ export const imageLipSyncModels = lipsyncModels.filter(m => m.category === 'imag
 export const videoLipSyncModels = lipsyncModels.filter(m => m.category === 'video');
 
 export const getV2VModelById = (id) => v2vModels.find(m => m.id === id);
+
+// ─── Novita Models (OpenAI-compatible endpoint: https://api.novita.ai/openai) ───────────────────
+// Model IDs use '/' separator, never '-'
+// Only t2i/i2i models are registered (video models not supported by Novita endpoint)
+export const t2iModels = [
+    {
+        "id": "deepseek/deepseek-v3.2",
+        "name": "DeepSeek V3.2",
+        "endpoint": "deepseek/deepseek-v3.2",
+        "inputs": {
+            "prompt": {
+                "type": "string",
+                "title": "Prompt",
+                "name": "prompt",
+                "description": "Text prompt describing the image.",
+                "examples": [
+                    "A futuristic city built from glowing crystal towers under a violet sky,with floating islands and cascading waterfalls, cinematic lighting, ultra-detailed sci-fi architecture."
+                ]
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "title": "Aspect Ratio",
+                "name": "aspect_ratio",
+                "description": "Aspect ratio of the output image.",
+                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
+                "default": "1:1"
+            },
+            "resolution": {
+                "type": "string",
+                "title": "Resolution",
+                "name": "resolution",
+                "enum": ["1k", "2k", "4k"],
+                "default": "1k"
+            }
+        }
+    },
+    {
+        "id": "zai-org/glm-5",
+        "name": "GLM-5",
+        "endpoint": "zai-org/glm-5",
+        "inputs": {
+            "prompt": {
+                "type": "string",
+                "title": "Prompt",
+                "name": "prompt",
+                "description": "Text prompt describing the image.",
+                "examples": [
+                    "A serene Japanese garden with cherry blossoms falling onto a koi pond, traditional wooden pavilion, foggy morning light, photorealistic detail."
+                ]
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "title": "Aspect Ratio",
+                "name": "aspect_ratio",
+                "description": "Aspect ratio of the output image.",
+                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
+                "default": "1:1"
+            },
+            "resolution": {
+                "type": "string",
+                "title": "Resolution",
+                "name": "resolution",
+                "enum": ["1k", "2k", "4k"],
+                "default": "1k"
+            }
+        }
+    },
+    {
+        "id": "minimax/minimax-m2.5",
+        "name": "MiniMax M2.5",
+        "endpoint": "minimax/minimax-m2.5",
+        "inputs": {
+            "prompt": {
+                "type": "string",
+                "title": "Prompt",
+                "name": "prompt",
+                "description": "Text prompt describing the image.",
+                "examples": [
+                    "A majestic lion standing on a rocky cliff at sunset, golden mane flowing in the wind, distant mountains painted in warm purple and orange hues, cinematic composition, ultra-realistic wildlife photography."
+                ]
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "title": "Aspect Ratio",
+                "name": "aspect_ratio",
+                "description": "Aspect ratio of the output image.",
+                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
+                "default": "1:1"
+            },
+            "resolution": {
+                "type": "string",
+                "title": "Resolution",
+                "name": "resolution",
+                "enum": ["1k", "2k", "4k"],
+                "default": "1k"
+            }
+        }
+    }
+];
+
+export const getNovitaT2IModelById = (id) => t2iModels.find(m => m.id === id);
+export const getNovitaResolutions = () => ["1k", "2k", "4k"];

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -8170,104 +8170,82 @@ export const videoLipSyncModels = lipsyncModels.filter(m => m.category === 'vide
 
 export const getV2VModelById = (id) => v2vModels.find(m => m.id === id);
 
-// ─── Novita Models (OpenAI-compatible endpoint: https://api.novita.ai/openai) ───────────────────
-// Model IDs use '/' separator, never '-'
-// Only t2i/i2i models are registered (video models not supported by Novita endpoint)
-export const t2iModels = [
-    {
-        "id": "deepseek/deepseek-v3.2",
-        "name": "DeepSeek V3.2",
-        "endpoint": "deepseek/deepseek-v3.2",
-        "inputs": {
-            "prompt": {
-                "type": "string",
-                "title": "Prompt",
-                "name": "prompt",
-                "description": "Text prompt describing the image.",
-                "examples": [
-                    "A futuristic city built from glowing crystal towers under a violet sky,with floating islands and cascading waterfalls, cinematic lighting, ultra-detailed sci-fi architecture."
-                ]
-            },
-            "aspect_ratio": {
-                "type": "string",
-                "title": "Aspect Ratio",
-                "name": "aspect_ratio",
-                "description": "Aspect ratio of the output image.",
-                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
-                "default": "1:1"
-            },
-            "resolution": {
-                "type": "string",
-                "title": "Resolution",
-                "name": "resolution",
-                "enum": ["1k", "2k", "4k"],
-                "default": "1k"
-            }
-        }
-    },
-    {
-        "id": "zai-org/glm-5",
-        "name": "GLM-5",
-        "endpoint": "zai-org/glm-5",
-        "inputs": {
-            "prompt": {
-                "type": "string",
-                "title": "Prompt",
-                "name": "prompt",
-                "description": "Text prompt describing the image.",
-                "examples": [
-                    "A serene Japanese garden with cherry blossoms falling onto a koi pond, traditional wooden pavilion, foggy morning light, photorealistic detail."
-                ]
-            },
-            "aspect_ratio": {
-                "type": "string",
-                "title": "Aspect Ratio",
-                "name": "aspect_ratio",
-                "description": "Aspect ratio of the output image.",
-                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
-                "default": "1:1"
-            },
-            "resolution": {
-                "type": "string",
-                "title": "Resolution",
-                "name": "resolution",
-                "enum": ["1k", "2k", "4k"],
-                "default": "1k"
-            }
-        }
-    },
-    {
-        "id": "minimax/minimax-m2.5",
-        "name": "MiniMax M2.5",
-        "endpoint": "minimax/minimax-m2.5",
-        "inputs": {
-            "prompt": {
-                "type": "string",
-                "title": "Prompt",
-                "name": "prompt",
-                "description": "Text prompt describing the image.",
-                "examples": [
-                    "A majestic lion standing on a rocky cliff at sunset, golden mane flowing in the wind, distant mountains painted in warm purple and orange hues, cinematic composition, ultra-realistic wildlife photography."
-                ]
-            },
-            "aspect_ratio": {
-                "type": "string",
-                "title": "Aspect Ratio",
-                "name": "aspect_ratio",
-                "description": "Aspect ratio of the output image.",
-                "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
-                "default": "1:1"
-            },
-            "resolution": {
-                "type": "string",
-                "title": "Resolution",
-                "name": "resolution",
-                "enum": ["1k", "2k", "4k"],
-                "default": "1k"
-            }
-        }
+// ─── Novita Models (v3 async model APIs) ─────────────────────────────────────
+export const novitaImageModels = [
+  {
+    "id": "seedream-5.0-lite",
+    "name": "Seedream 5.0 Lite",
+    "endpoint": "seedream-5.0-lite",
+    "inputs": {
+      "prompt": { "type": "string", "title": "Prompt", "name": "prompt" },
+      "aspect_ratio": {
+        "type": "string",
+        "title": "Aspect Ratio",
+        "name": "aspect_ratio",
+        "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
+        "default": "1:1"
+      },
+      "resolution": {
+        "type": "string",
+        "title": "Resolution",
+        "name": "resolution",
+        "enum": ["1k", "2k", "4k"],
+        "default": "1k"
+      }
     }
+  },
+  {
+    "id": "flux-1-schnell",
+    "name": "Flux 1 Schnell",
+    "endpoint": "flux-1-schnell",
+    "inputs": {
+      "prompt": { "type": "string", "title": "Prompt", "name": "prompt" },
+      "aspect_ratio": {
+        "type": "string",
+        "title": "Aspect Ratio",
+        "name": "aspect_ratio",
+        "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
+        "default": "1:1"
+      },
+      "resolution": {
+        "type": "string",
+        "title": "Resolution",
+        "name": "resolution",
+        "enum": ["1k", "2k", "4k"],
+        "default": "1k"
+      }
+    }
+  },
+  {
+    "id": "qwen-image",
+    "name": "Qwen Image",
+    "endpoint": "qwen-image",
+    "inputs": {
+      "prompt": { "type": "string", "title": "Prompt", "name": "prompt" },
+      "aspect_ratio": {
+        "type": "string",
+        "title": "Aspect Ratio",
+        "name": "aspect_ratio",
+        "enum": ["1:1", "16:9", "9:16", "4:3", "3:4"],
+        "default": "1:1"
+      },
+      "resolution": {
+        "type": "string",
+        "title": "Resolution",
+        "name": "resolution",
+        "enum": ["1k", "2k", "4k"],
+        "default": "1k"
+      }
+    }
+  }
 ];
 
-export const getNovitaT2IModelById = (id) => t2iModels.find(m => m.id === id);
+export const novitaVideoModels = [
+  { "id": "kling-v3.0-pro-t2v", "name": "Kling V3.0 Pro T2V", "endpoint": "kling-v3.0-pro-t2v" },
+  { "id": "vidu-q3-pro-t2v", "name": "Vidu Q3 Pro T2V", "endpoint": "vidu-q3-pro-t2v" },
+  { "id": "wan2.6-t2v", "name": "Wan 2.6 T2V", "endpoint": "wan2.6-t2v" }
+];
+
+export const getNovitaImageModelById = (id) => novitaImageModels.find(m => m.id === id);
+export const getNovitaVideoModelById = (id) => novitaVideoModels.find(m => m.id === id);
 export const getNovitaResolutions = () => ["1k", "2k", "4k"];

--- a/src/lib/muapi.js
+++ b/src/lib/muapi.js
@@ -3,7 +3,8 @@ import { getModelById, getVideoModelById, getI2IModelById, getI2VModelById, getV
 export class MuapiClient {
     constructor() {
         // Ideally user provides this in settings
-        this.baseUrl = import.meta.env.DEV ? '' : 'https://api.muapi.ai';
+        const isDev = typeof import.meta !== 'undefined' && import.meta?.env?.DEV;
+        this.baseUrl = isDev ? '' : 'https://api.muapi.ai';
     }
 
     getKey() {

--- a/src/lib/novita.js
+++ b/src/lib/novita.js
@@ -1,8 +1,8 @@
-import { getModelById, getVideoModelById, getI2IModelById, getI2VModelById, getV2VModelById, getLipSyncModelById } from './models.js';
+import { getNovitaImageModelById, getNovitaVideoModelById } from './models.js';
 
 export class NovitaClient {
     constructor() {
-        this.baseUrl = 'https://api.novita.ai/openai';
+        this.baseUrl = 'https://api.novita.ai/v3/async';
     }
 
     getKey() {
@@ -11,518 +11,205 @@ export class NovitaClient {
         return key;
     }
 
-    /**
-     * Generates an image (Text-to-Image or Image-to-Image)
-     * @param {Object} params
-     * @param {string} params.model - Model ID (e.g., 'deepseek/deepseek-v3.2')
-     * @param {string} params.prompt
-     * @param {string} params.negative_prompt
-     * @param {string} params.aspect_ratio
-     * @param {number} params.steps
-     * @param {number} params.guidance_scale
-     * @param {number} params.seed
-     * @param {string} [params.image_url] - If present, treats as Image-to-Image
-     */
-    async generateImage(params) {
-        const key = this.getKey();
-
-        // Resolve endpoint from model definition (if available)
-        const modelInfo = getModelById(params.model);
-        const endpoint = modelInfo?.endpoint || params.model;
-        const url = `${this.baseUrl}/images/generations`;
-
-        // Build payload matching OpenAI-compatible format
-        const finalPayload = {
-            model: endpoint,
-            prompt: params.prompt,
-            n: 1,
-        };
-
-        // Aspect ratio → width/height mapping
-        if (params.aspect_ratio) {
-            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
-            finalPayload.width = width;
-            finalPayload.height = height;
-        }
-
-        // Resolution override
-        if (params.resolution) {
-            if (params.resolution === '1k') {
-                finalPayload.width = 1024;
-                finalPayload.height = 1024;
-            } else if (params.resolution === '2k') {
-                finalPayload.width = 1440;
-                finalPayload.height = 1440;
-            } else if (params.resolution === '4k') {
-                finalPayload.width = 2048;
-                finalPayload.height = 2048;
-            }
-        }
-
-        // Quality (used by seedream and similar models)
-        if (params.quality) {
-            finalPayload.quality = params.quality;
-        }
-
-        // Image-to-Image (not directly supported by OpenAI-compatible endpoint,
-        // but some providers may have extensions)
-        if (params.image_url) {
-            finalPayload.image_url = params.image_url;
-        }
-
-        // Optional params if supported by model
-        if (params.seed && params.seed !== -1) {
-            finalPayload.seed = params.seed;
-        }
-
-        console.log('[Novita] Requesting:', url);
-        console.log('[Novita] Payload:', finalPayload);
-
-        try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${key}`
-                },
-                body: JSON.stringify(finalPayload)
-            });
-
-            if (!response.ok) {
-                const errText = await response.text();
-                console.error('[Novita] API Error Body:', errText);
-                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
-            }
-
-            const data = await response.json();
-            console.log('[Novita] Response:', data);
-
-            // Extract image URL from OpenAI-compatible response format
-            const imageUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
-            console.log('[Novita] Image URL:', imageUrl);
-
-            return { ...data, url: imageUrl };
-
-        } catch (error) {
-            console.error("Novita Client Error:", error);
-            throw error;
+    getDimensionsFromAR(ar) {
+        switch (ar) {
+            case '1:1': return [1024, 1024];
+            case '16:9': return [1280, 720];
+            case '9:16': return [720, 1280];
+            case '4:3': return [1152, 864];
+            case '3:4': return [864, 1152];
+            case '3:2': return [1216, 832];
+            case '2:3': return [832, 1216];
+            case '21:9': return [1536, 640];
+            default: return [1024, 1024];
         }
     }
 
-    /**
-     * Polls the predictions endpoint until the result is ready.
-     * @param {string} requestId - The request ID from the submit response
-     * @param {string} key - The API key
-     * @param {number} maxAttempts - Maximum polling attempts (default 60 = ~2 min)
-     * @param {number} interval - Polling interval in ms (default 2000)
-     */
-    async pollForResult(requestId, key, maxAttempts = 60, interval = 2000) {
-        const pollUrl = `${this.baseUrl}/images/${requestId}`;
+    applyResolution(payload, resolution) {
+        if (resolution === '1k') {
+            payload.width = 1024;
+            payload.height = 1024;
+        } else if (resolution === '2k') {
+            payload.width = 1440;
+            payload.height = 1440;
+        } else if (resolution === '4k') {
+            payload.width = 2048;
+            payload.height = 2048;
+        }
+    }
+
+    async submitTask(path, payload, key) {
+        const url = `${this.baseUrl}/${path}`;
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${key}`
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            const errText = await response.text();
+            throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 140)}`);
+        }
+
+        const data = await response.json();
+        const taskId = data.task_id;
+        if (!taskId) throw new Error('Novita async API did not return task_id.');
+        return taskId;
+    }
+
+    async pollTaskResult(taskId, key, maxAttempts = 180, interval = 2000) {
+        const url = `${this.baseUrl}/task-result?task_id=${encodeURIComponent(taskId)}`;
 
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
             await new Promise(resolve => setTimeout(resolve, interval));
 
-            console.log(`[Novita] Polling attempt ${attempt}/${maxAttempts}...`);
-
-            try {
-                const response = await fetch(pollUrl, {
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${key}`
-                    }
-                });
-
-                if (!response.ok) {
-                    const errText = await response.text();
-                    console.warn(`[Novita] Poll error (${response.status}):`, errText);
-                    // Continue polling on non-fatal errors
-                    if (response.status >= 500) continue;
-                    throw new Error(`Poll Failed: ${response.status} - ${errText.slice(0, 100)}`);
+            const response = await fetch(url, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${key}`
                 }
+            });
 
-                const data = await response.json();
-                console.log('[Novita] Poll Response:', data);
+            if (!response.ok) {
+                const errText = await response.text();
+                if (response.status >= 500) continue;
+                throw new Error(`Poll Failed: ${response.status} - ${errText.slice(0, 140)}`);
+            }
 
-                const status = data.status?.toLowerCase();
+            const data = await response.json();
+            const status = data?.task?.status;
 
-                if (status === 'completed' || status === 'succeeded' || status === 'success') {
-                    return data;
-                }
-
-                if (status === 'failed' || status === 'error') {
-                    throw new Error(`Generation failed: ${data.error || 'Unknown error'}`);
-                }
-
-                // Otherwise (processing, pending, etc.) keep polling
-            } catch (error) {
-                if (attempt === maxAttempts) throw error;
-                console.warn('[Novita] Poll attempt failed, retrying...', error.message);
+            if (status === 'TASK_STATUS_SUCCEED') return data;
+            if (status === 'TASK_STATUS_FAILED') {
+                throw new Error(`Generation failed: ${data?.task?.reason || 'Unknown error'}`);
             }
         }
 
         throw new Error('Generation timed out after polling.');
     }
 
+    async generateImage(params) {
+        const key = this.getKey();
+        const modelInfo = getNovitaImageModelById(params.model);
+        const modelName = modelInfo?.endpoint || params.model;
+
+        const request = {
+            model_name: modelName,
+            prompt: params.prompt,
+            width: 1024,
+            height: 1024,
+            image_num: 1,
+            steps: params.steps || 20,
+            guidance_scale: params.guidance_scale || 7.5,
+            sampler_name: params.sampler_name || 'Euler a'
+        };
+
+        if (params.aspect_ratio) {
+            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
+            request.width = width;
+            request.height = height;
+        }
+        if (params.resolution) this.applyResolution(request, params.resolution);
+        if (params.negative_prompt) request.negative_prompt = params.negative_prompt;
+        if (typeof params.seed === 'number') request.seed = params.seed;
+
+        const taskId = await this.submitTask('txt2img', { request }, key);
+        if (params.onRequestId) params.onRequestId(taskId);
+
+        const result = await this.pollTaskResult(taskId, key);
+        const imageUrl = result.images?.[0]?.image_url;
+        return { ...result, request_id: taskId, url: imageUrl };
+    }
+
     async generateVideo(params) {
         const key = this.getKey();
+        const modelInfo = getNovitaVideoModelById(params.model);
+        const modelName = modelInfo?.endpoint || params.model;
 
-        const modelInfo = getVideoModelById(params.model);
-        const endpoint = modelInfo?.endpoint || params.model;
-        const url = `${this.baseUrl}/videos/generations`;
+        let width = 1024;
+        let height = 576;
+        if (params.aspect_ratio) {
+            [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
+        }
 
-        const finalPayload = {
-            model: endpoint,
-            prompt: params.prompt,
-            n: 1,
+        const duration = Number(params.duration) || 5;
+        const frames = Math.max(8, Math.min(128, duration * 16));
+
+        const payload = {
+            model_name: modelName,
+            width,
+            height,
+            steps: params.steps || 20,
+            prompts: [{ frames, prompt: params.prompt }]
         };
 
-        if (params.aspect_ratio) {
-            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
-            finalPayload.width = width;
-            finalPayload.height = height;
-        }
+        if (params.negative_prompt) payload.negative_prompt = params.negative_prompt;
+        if (typeof params.seed === 'number') payload.seed = params.seed;
+        if (params.resolution) this.applyResolution(payload, params.resolution);
 
-        if (params.resolution) {
-            if (params.resolution === '1k') {
-                finalPayload.width = 1024;
-                finalPayload.height = 1024;
-            } else if (params.resolution === '2k') {
-                finalPayload.width = 1440;
-                finalPayload.height = 1440;
-            } else if (params.resolution === '4k') {
-                finalPayload.width = 2048;
-                finalPayload.height = 2048;
-            }
-        }
+        const taskId = await this.submitTask('txt2video', payload, key);
+        if (params.onRequestId) params.onRequestId(taskId);
 
-        if (params.duration) finalPayload.duration = params.duration;
-        if (params.quality) finalPayload.quality = params.quality;
-
-        console.log('[Novita] Video Request:', url);
-        console.log('[Novita] Video Payload:', finalPayload);
-
-        try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${key}`
-                },
-                body: JSON.stringify(finalPayload)
-            });
-
-            if (!response.ok) {
-                const errText = await response.text();
-                console.error('[Novita] Video API Error Body:', errText);
-                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
-            }
-
-            const data = await response.json();
-            console.log('[Novita] Video Response:', data);
-
-            // Extract video URL from response
-            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
-            console.log('[Novita] Video URL:', videoUrl);
-
-            return { ...data, url: videoUrl };
-
-        } catch (error) {
-            console.error("Novita Video Client Error:", error);
-            throw error;
-        }
+        const result = await this.pollTaskResult(taskId, key, 360, 2500);
+        const videoUrl = result.videos?.[0]?.video_url;
+        return { ...result, request_id: taskId, url: videoUrl };
     }
 
-    /**
-     * Generates an image using an Image-to-Image model.
-     * @param {Object} params
-     * @param {string} params.model - i2iModel id
-     * @param {string} params.image_url - The uploaded reference image URL
-     * @param {string} [params.prompt] - Optional text prompt
-     * @param {string} [params.aspect_ratio]
-     * @param {string} [params.resolution]
-     */
     async generateI2I(params) {
-        const key = this.getKey();
-        const modelInfo = getI2IModelById(params.model);
-        const endpoint = modelInfo?.endpoint || params.model;
-        const url = `${this.baseUrl}/images/generations`;
+        if (!params.image_base64) {
+            throw new Error('Novita i2i requires image_base64 for /v3/async/img2img.');
+        }
 
-        const finalPayload = {
-            model: endpoint,
+        const key = this.getKey();
+        const modelInfo = getNovitaImageModelById(params.model);
+        const modelName = modelInfo?.endpoint || params.model;
+
+        const request = {
+            model_name: modelName,
+            image_base64: params.image_base64,
             prompt: params.prompt || '',
-            image_url: params.image_url,
-            n: 1,
+            width: 1024,
+            height: 1024,
+            image_num: 1,
+            steps: params.steps || 20,
+            guidance_scale: params.guidance_scale || 7.5,
+            sampler_name: params.sampler_name || 'Euler a'
         };
 
         if (params.aspect_ratio) {
             const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
-            finalPayload.width = width;
-            finalPayload.height = height;
+            request.width = width;
+            request.height = height;
         }
+        if (params.resolution) this.applyResolution(request, params.resolution);
+        if (typeof params.seed === 'number') request.seed = params.seed;
 
-        if (params.resolution) {
-            if (params.resolution === '1k') {
-                finalPayload.width = 1024;
-                finalPayload.height = 1024;
-            } else if (params.resolution === '2k') {
-                finalPayload.width = 1440;
-                finalPayload.height = 1440;
-            } else if (params.resolution === '4k') {
-                finalPayload.width = 2048;
-                finalPayload.height = 2048;
-            }
-        }
+        const taskId = await this.submitTask('img2img', { request }, key);
+        if (params.onRequestId) params.onRequestId(taskId);
 
-        if (params.quality) finalPayload.quality = params.quality;
-
-        console.log('[Novita] I2I Request:', url);
-        console.log('[Novita] I2I Payload:', finalPayload);
-
-        try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
-                body: JSON.stringify(finalPayload)
-            });
-
-            if (!response.ok) {
-                const errText = await response.text();
-                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
-            }
-
-            const data = await response.json();
-            console.log('[Novita] I2I Response:', data);
-
-            const imageUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
-            console.log('[Novita] I2I Result URL:', imageUrl);
-            return { ...data, url: imageUrl };
-
-        } catch (error) {
-            console.error('Novita I2I Error:', error);
-            throw error;
-        }
+        const result = await this.pollTaskResult(taskId, key);
+        const imageUrl = result.images?.[0]?.image_url;
+        return { ...result, request_id: taskId, url: imageUrl };
     }
 
-    /**
-     * Generates a video using an Image-to-Video model.
-     * @param {Object} params
-     * @param {string} params.model - i2vModel id
-     * @param {string} params.image_url - The uploaded start frame image URL
-     * @param {string} [params.prompt]
-     * @param {string} [params.aspect_ratio]
-     * @param {string} [params.resolution]
-     * @param {number} [params.duration]
-     * @param {string} [params.quality]
-     */
-    async generateI2V(params) {
-        const key = this.getKey();
-        const modelInfo = getI2VModelById(params.model);
-        const endpoint = modelInfo?.endpoint || params.model;
-        const url = `${this.baseUrl}/videos/generations`;
-
-        const finalPayload = {
-            model: endpoint,
-            prompt: params.prompt || '',
-            image_url: params.image_url,
-            n: 1,
-        };
-
-        if (params.aspect_ratio) {
-            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
-            finalPayload.width = width;
-            finalPayload.height = height;
-        }
-
-        if (params.resolution) {
-            if (params.resolution === '1k') {
-                finalPayload.width = 1024;
-                finalPayload.height = 1024;
-            } else if (params.resolution === '2k') {
-                finalPayload.width = 1440;
-                finalPayload.height = 1440;
-            } else if (params.resolution === '4k') {
-                finalPayload.width = 2048;
-                finalPayload.height = 2048;
-            }
-        }
-
-        if (params.duration) finalPayload.duration = params.duration;
-        if (params.quality) finalPayload.quality = params.quality;
-
-        console.log('[Novita] I2V Request:', url);
-        console.log('[Novita] I2V Payload:', finalPayload);
-
-        try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
-                body: JSON.stringify(finalPayload)
-            });
-
-            if (!response.ok) {
-                const errText = await response.text();
-                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
-            }
-
-            const data = await response.json();
-            console.log('[Novita] I2V Response:', data);
-
-            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
-            console.log('[Novita] I2V Result URL:', videoUrl);
-            return { ...data, url: videoUrl };
-
-        } catch (error) {
-            console.error('Novita I2V Error:', error);
-            throw error;
-        }
+    async generateI2V() {
+        throw new Error('Novita i2v in this client is not implemented yet. Use txt2video or extend with /v3/async/img2video + base64.');
     }
 
-    /**
-     * Uploads a file to novita and returns the hosted URL.
-     * @param {File} file - The image file to upload
-     * @returns {Promise<string>} The hosted URL of the uploaded file
-     */
-    async uploadFile(file) {
-        const key = this.getKey();
-        const url = `${this.baseUrl}/files`;
-
-        const formData = new FormData();
-        formData.append('file', file);
-
-        console.log('[Novita] Uploading file:', file.name);
-
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: { 'Authorization': `Bearer ${key}` },
-            body: formData
-        });
-
-        if (!response.ok) {
-            const errText = await response.text();
-            throw new Error(`File upload failed: ${response.status} - ${errText.slice(0, 100)}`);
-        }
-
-        const data = await response.json();
-        console.log('[Novita] Upload response:', data);
-
-        const fileUrl = data.url || data.file_url || data.data?.url;
-        if (!fileUrl) throw new Error('No URL returned from file upload');
-        return fileUrl;
+    async uploadFile() {
+        throw new Error('Novita v3 media APIs require base64 inputs for i2i/i2v; uploadFile is not supported in this client.');
     }
 
-    /**
-     * Processes a video through a Video-to-Video model (e.g. watermark remover).
-     * @param {Object} params
-     * @param {string} params.model - v2vModel id
-     * @param {string} params.video_url - The uploaded video URL
-     */
-    async processV2V(params) {
-        const key = this.getKey();
-        const modelInfo = getV2VModelById(params.model);
-        const endpoint = modelInfo?.endpoint || params.model;
-        const url = `${this.baseUrl}/videos/generations`;
-
-        const finalPayload = {
-            model: endpoint,
-            video_url: params.video_url,
-            n: 1,
-        };
-
-        console.log('[Novita] V2V Request:', url);
-        console.log('[Novita] V2V Payload:', finalPayload);
-
-        try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
-                body: JSON.stringify(finalPayload)
-            });
-
-            if (!response.ok) {
-                const errText = await response.text();
-                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
-            }
-
-            const data = await response.json();
-            console.log('[Novita] V2V Response:', data);
-
-            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
-            console.log('[Novita] V2V Result URL:', videoUrl);
-            return { ...data, url: videoUrl };
-        } catch (error) {
-            console.error('Novita V2V Error:', error);
-            throw error;
-        }
+    async processV2V() {
+        throw new Error('Novita v3 video-edit endpoint is not implemented yet in this client.');
     }
 
-    /**
-     * Processes lipsync / speech-to-video generation.
-     * Supports image+audio → video and video+audio → video models.
-     * @param {Object} params
-     * @param {string} params.model - lipsyncModel id
-     * @param {string} [params.image_url] - Portrait image URL (image-based models)
-     * @param {string} [params.video_url] - Source video URL (video-based models)
-     * @param {string} params.audio_url - Audio file URL
-     * @param {string} [params.prompt] - Optional prompt (for models that support it)
-     * @param {string} [params.resolution] - Output resolution
-     */
-    async processLipSync(params) {
-        const key = this.getKey();
-        const modelInfo = getLipSyncModelById(params.model);
-        const endpoint = modelInfo?.endpoint || params.model;
-        const url = `${this.baseUrl}/videos/generations`;
-
-        const finalPayload = {
-            model: endpoint,
-            audio_url: params.audio_url,
-            n: 1,
-        };
-
-        if (params.image_url) finalPayload.image_url = params.image_url;
-        if (params.video_url) finalPayload.video_url = params.video_url;
-        if (params.prompt) finalPayload.prompt = params.prompt;
-        if (params.resolution) finalPayload.resolution = params.resolution;
-
-        console.log('[Novita] LipSync Request:', url);
-        console.log('[Novita] LipSync Payload:', finalPayload);
-
-        try {
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
-                body: JSON.stringify(finalPayload)
-            });
-
-            if (!response.ok) {
-                const errText = await response.text();
-                console.error('[Novita] LipSync API Error:', errText);
-                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
-            }
-
-            const data = await response.json();
-            console.log('[Novita] LipSync Response:', data);
-
-            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
-            console.log('[Novita] LipSync Result URL:', videoUrl);
-            return { ...data, url: videoUrl };
-        } catch (error) {
-            console.error('Novita LipSync Error:', error);
-            throw error;
-        }
-    }
-
-    getDimensionsFromAR(ar) {
-        // Base unit 1024 (Flux standard)
-        switch (ar) {
-            case '1:1': return [1024, 1024];
-            case '16:9': return [1280, 720];
-            case '9:16': return [720, 1280];
-            case '4:3': return [1152, 864];
-            case '3:2': return [1216, 832];
-            case '21:9': return [1536, 640];
-            default: return [1024, 1024];
-        }
+    async processLipSync() {
+        throw new Error('Novita lipsync endpoint is not implemented yet in this client.');
     }
 }
 

--- a/src/lib/novita.js
+++ b/src/lib/novita.js
@@ -1,0 +1,529 @@
+import { getModelById, getVideoModelById, getI2IModelById, getI2VModelById, getV2VModelById, getLipSyncModelById } from './models.js';
+
+export class NovitaClient {
+    constructor() {
+        this.baseUrl = 'https://api.novita.ai/openai';
+    }
+
+    getKey() {
+        const key = localStorage.getItem('novita_api_key');
+        if (!key) throw new Error('API Key missing. Please set it in Settings.');
+        return key;
+    }
+
+    /**
+     * Generates an image (Text-to-Image or Image-to-Image)
+     * @param {Object} params
+     * @param {string} params.model - Model ID (e.g., 'deepseek/deepseek-v3.2')
+     * @param {string} params.prompt
+     * @param {string} params.negative_prompt
+     * @param {string} params.aspect_ratio
+     * @param {number} params.steps
+     * @param {number} params.guidance_scale
+     * @param {number} params.seed
+     * @param {string} [params.image_url] - If present, treats as Image-to-Image
+     */
+    async generateImage(params) {
+        const key = this.getKey();
+
+        // Resolve endpoint from model definition (if available)
+        const modelInfo = getModelById(params.model);
+        const endpoint = modelInfo?.endpoint || params.model;
+        const url = `${this.baseUrl}/images/generations`;
+
+        // Build payload matching OpenAI-compatible format
+        const finalPayload = {
+            model: endpoint,
+            prompt: params.prompt,
+            n: 1,
+        };
+
+        // Aspect ratio → width/height mapping
+        if (params.aspect_ratio) {
+            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
+            finalPayload.width = width;
+            finalPayload.height = height;
+        }
+
+        // Resolution override
+        if (params.resolution) {
+            if (params.resolution === '1k') {
+                finalPayload.width = 1024;
+                finalPayload.height = 1024;
+            } else if (params.resolution === '2k') {
+                finalPayload.width = 1440;
+                finalPayload.height = 1440;
+            } else if (params.resolution === '4k') {
+                finalPayload.width = 2048;
+                finalPayload.height = 2048;
+            }
+        }
+
+        // Quality (used by seedream and similar models)
+        if (params.quality) {
+            finalPayload.quality = params.quality;
+        }
+
+        // Image-to-Image (not directly supported by OpenAI-compatible endpoint,
+        // but some providers may have extensions)
+        if (params.image_url) {
+            finalPayload.image_url = params.image_url;
+        }
+
+        // Optional params if supported by model
+        if (params.seed && params.seed !== -1) {
+            finalPayload.seed = params.seed;
+        }
+
+        console.log('[Novita] Requesting:', url);
+        console.log('[Novita] Payload:', finalPayload);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${key}`
+                },
+                body: JSON.stringify(finalPayload)
+            });
+
+            if (!response.ok) {
+                const errText = await response.text();
+                console.error('[Novita] API Error Body:', errText);
+                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+            }
+
+            const data = await response.json();
+            console.log('[Novita] Response:', data);
+
+            // Extract image URL from OpenAI-compatible response format
+            const imageUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
+            console.log('[Novita] Image URL:', imageUrl);
+
+            return { ...data, url: imageUrl };
+
+        } catch (error) {
+            console.error("Novita Client Error:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Polls the predictions endpoint until the result is ready.
+     * @param {string} requestId - The request ID from the submit response
+     * @param {string} key - The API key
+     * @param {number} maxAttempts - Maximum polling attempts (default 60 = ~2 min)
+     * @param {number} interval - Polling interval in ms (default 2000)
+     */
+    async pollForResult(requestId, key, maxAttempts = 60, interval = 2000) {
+        const pollUrl = `${this.baseUrl}/images/${requestId}`;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            await new Promise(resolve => setTimeout(resolve, interval));
+
+            console.log(`[Novita] Polling attempt ${attempt}/${maxAttempts}...`);
+
+            try {
+                const response = await fetch(pollUrl, {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${key}`
+                    }
+                });
+
+                if (!response.ok) {
+                    const errText = await response.text();
+                    console.warn(`[Novita] Poll error (${response.status}):`, errText);
+                    // Continue polling on non-fatal errors
+                    if (response.status >= 500) continue;
+                    throw new Error(`Poll Failed: ${response.status} - ${errText.slice(0, 100)}`);
+                }
+
+                const data = await response.json();
+                console.log('[Novita] Poll Response:', data);
+
+                const status = data.status?.toLowerCase();
+
+                if (status === 'completed' || status === 'succeeded' || status === 'success') {
+                    return data;
+                }
+
+                if (status === 'failed' || status === 'error') {
+                    throw new Error(`Generation failed: ${data.error || 'Unknown error'}`);
+                }
+
+                // Otherwise (processing, pending, etc.) keep polling
+            } catch (error) {
+                if (attempt === maxAttempts) throw error;
+                console.warn('[Novita] Poll attempt failed, retrying...', error.message);
+            }
+        }
+
+        throw new Error('Generation timed out after polling.');
+    }
+
+    async generateVideo(params) {
+        const key = this.getKey();
+
+        const modelInfo = getVideoModelById(params.model);
+        const endpoint = modelInfo?.endpoint || params.model;
+        const url = `${this.baseUrl}/videos/generations`;
+
+        const finalPayload = {
+            model: endpoint,
+            prompt: params.prompt,
+            n: 1,
+        };
+
+        if (params.aspect_ratio) {
+            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
+            finalPayload.width = width;
+            finalPayload.height = height;
+        }
+
+        if (params.resolution) {
+            if (params.resolution === '1k') {
+                finalPayload.width = 1024;
+                finalPayload.height = 1024;
+            } else if (params.resolution === '2k') {
+                finalPayload.width = 1440;
+                finalPayload.height = 1440;
+            } else if (params.resolution === '4k') {
+                finalPayload.width = 2048;
+                finalPayload.height = 2048;
+            }
+        }
+
+        if (params.duration) finalPayload.duration = params.duration;
+        if (params.quality) finalPayload.quality = params.quality;
+
+        console.log('[Novita] Video Request:', url);
+        console.log('[Novita] Video Payload:', finalPayload);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${key}`
+                },
+                body: JSON.stringify(finalPayload)
+            });
+
+            if (!response.ok) {
+                const errText = await response.text();
+                console.error('[Novita] Video API Error Body:', errText);
+                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+            }
+
+            const data = await response.json();
+            console.log('[Novita] Video Response:', data);
+
+            // Extract video URL from response
+            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
+            console.log('[Novita] Video URL:', videoUrl);
+
+            return { ...data, url: videoUrl };
+
+        } catch (error) {
+            console.error("Novita Video Client Error:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Generates an image using an Image-to-Image model.
+     * @param {Object} params
+     * @param {string} params.model - i2iModel id
+     * @param {string} params.image_url - The uploaded reference image URL
+     * @param {string} [params.prompt] - Optional text prompt
+     * @param {string} [params.aspect_ratio]
+     * @param {string} [params.resolution]
+     */
+    async generateI2I(params) {
+        const key = this.getKey();
+        const modelInfo = getI2IModelById(params.model);
+        const endpoint = modelInfo?.endpoint || params.model;
+        const url = `${this.baseUrl}/images/generations`;
+
+        const finalPayload = {
+            model: endpoint,
+            prompt: params.prompt || '',
+            image_url: params.image_url,
+            n: 1,
+        };
+
+        if (params.aspect_ratio) {
+            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
+            finalPayload.width = width;
+            finalPayload.height = height;
+        }
+
+        if (params.resolution) {
+            if (params.resolution === '1k') {
+                finalPayload.width = 1024;
+                finalPayload.height = 1024;
+            } else if (params.resolution === '2k') {
+                finalPayload.width = 1440;
+                finalPayload.height = 1440;
+            } else if (params.resolution === '4k') {
+                finalPayload.width = 2048;
+                finalPayload.height = 2048;
+            }
+        }
+
+        if (params.quality) finalPayload.quality = params.quality;
+
+        console.log('[Novita] I2I Request:', url);
+        console.log('[Novita] I2I Payload:', finalPayload);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+                body: JSON.stringify(finalPayload)
+            });
+
+            if (!response.ok) {
+                const errText = await response.text();
+                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+            }
+
+            const data = await response.json();
+            console.log('[Novita] I2I Response:', data);
+
+            const imageUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
+            console.log('[Novita] I2I Result URL:', imageUrl);
+            return { ...data, url: imageUrl };
+
+        } catch (error) {
+            console.error('Novita I2I Error:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Generates a video using an Image-to-Video model.
+     * @param {Object} params
+     * @param {string} params.model - i2vModel id
+     * @param {string} params.image_url - The uploaded start frame image URL
+     * @param {string} [params.prompt]
+     * @param {string} [params.aspect_ratio]
+     * @param {string} [params.resolution]
+     * @param {number} [params.duration]
+     * @param {string} [params.quality]
+     */
+    async generateI2V(params) {
+        const key = this.getKey();
+        const modelInfo = getI2VModelById(params.model);
+        const endpoint = modelInfo?.endpoint || params.model;
+        const url = `${this.baseUrl}/videos/generations`;
+
+        const finalPayload = {
+            model: endpoint,
+            prompt: params.prompt || '',
+            image_url: params.image_url,
+            n: 1,
+        };
+
+        if (params.aspect_ratio) {
+            const [width, height] = this.getDimensionsFromAR(params.aspect_ratio);
+            finalPayload.width = width;
+            finalPayload.height = height;
+        }
+
+        if (params.resolution) {
+            if (params.resolution === '1k') {
+                finalPayload.width = 1024;
+                finalPayload.height = 1024;
+            } else if (params.resolution === '2k') {
+                finalPayload.width = 1440;
+                finalPayload.height = 1440;
+            } else if (params.resolution === '4k') {
+                finalPayload.width = 2048;
+                finalPayload.height = 2048;
+            }
+        }
+
+        if (params.duration) finalPayload.duration = params.duration;
+        if (params.quality) finalPayload.quality = params.quality;
+
+        console.log('[Novita] I2V Request:', url);
+        console.log('[Novita] I2V Payload:', finalPayload);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+                body: JSON.stringify(finalPayload)
+            });
+
+            if (!response.ok) {
+                const errText = await response.text();
+                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+            }
+
+            const data = await response.json();
+            console.log('[Novita] I2V Response:', data);
+
+            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
+            console.log('[Novita] I2V Result URL:', videoUrl);
+            return { ...data, url: videoUrl };
+
+        } catch (error) {
+            console.error('Novita I2V Error:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Uploads a file to novita and returns the hosted URL.
+     * @param {File} file - The image file to upload
+     * @returns {Promise<string>} The hosted URL of the uploaded file
+     */
+    async uploadFile(file) {
+        const key = this.getKey();
+        const url = `${this.baseUrl}/files`;
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        console.log('[Novita] Uploading file:', file.name);
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${key}` },
+            body: formData
+        });
+
+        if (!response.ok) {
+            const errText = await response.text();
+            throw new Error(`File upload failed: ${response.status} - ${errText.slice(0, 100)}`);
+        }
+
+        const data = await response.json();
+        console.log('[Novita] Upload response:', data);
+
+        const fileUrl = data.url || data.file_url || data.data?.url;
+        if (!fileUrl) throw new Error('No URL returned from file upload');
+        return fileUrl;
+    }
+
+    /**
+     * Processes a video through a Video-to-Video model (e.g. watermark remover).
+     * @param {Object} params
+     * @param {string} params.model - v2vModel id
+     * @param {string} params.video_url - The uploaded video URL
+     */
+    async processV2V(params) {
+        const key = this.getKey();
+        const modelInfo = getV2VModelById(params.model);
+        const endpoint = modelInfo?.endpoint || params.model;
+        const url = `${this.baseUrl}/videos/generations`;
+
+        const finalPayload = {
+            model: endpoint,
+            video_url: params.video_url,
+            n: 1,
+        };
+
+        console.log('[Novita] V2V Request:', url);
+        console.log('[Novita] V2V Payload:', finalPayload);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+                body: JSON.stringify(finalPayload)
+            });
+
+            if (!response.ok) {
+                const errText = await response.text();
+                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+            }
+
+            const data = await response.json();
+            console.log('[Novita] V2V Response:', data);
+
+            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
+            console.log('[Novita] V2V Result URL:', videoUrl);
+            return { ...data, url: videoUrl };
+        } catch (error) {
+            console.error('Novita V2V Error:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Processes lipsync / speech-to-video generation.
+     * Supports image+audio → video and video+audio → video models.
+     * @param {Object} params
+     * @param {string} params.model - lipsyncModel id
+     * @param {string} [params.image_url] - Portrait image URL (image-based models)
+     * @param {string} [params.video_url] - Source video URL (video-based models)
+     * @param {string} params.audio_url - Audio file URL
+     * @param {string} [params.prompt] - Optional prompt (for models that support it)
+     * @param {string} [params.resolution] - Output resolution
+     */
+    async processLipSync(params) {
+        const key = this.getKey();
+        const modelInfo = getLipSyncModelById(params.model);
+        const endpoint = modelInfo?.endpoint || params.model;
+        const url = `${this.baseUrl}/videos/generations`;
+
+        const finalPayload = {
+            model: endpoint,
+            audio_url: params.audio_url,
+            n: 1,
+        };
+
+        if (params.image_url) finalPayload.image_url = params.image_url;
+        if (params.video_url) finalPayload.video_url = params.video_url;
+        if (params.prompt) finalPayload.prompt = params.prompt;
+        if (params.resolution) finalPayload.resolution = params.resolution;
+
+        console.log('[Novita] LipSync Request:', url);
+        console.log('[Novita] LipSync Payload:', finalPayload);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+                body: JSON.stringify(finalPayload)
+            });
+
+            if (!response.ok) {
+                const errText = await response.text();
+                console.error('[Novita] LipSync API Error:', errText);
+                throw new Error(`API Request Failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+            }
+
+            const data = await response.json();
+            console.log('[Novita] LipSync Response:', data);
+
+            const videoUrl = data.data?.[0]?.url || data.choices?.[0]?.message?.content;
+            console.log('[Novita] LipSync Result URL:', videoUrl);
+            return { ...data, url: videoUrl };
+        } catch (error) {
+            console.error('Novita LipSync Error:', error);
+            throw error;
+        }
+    }
+
+    getDimensionsFromAR(ar) {
+        // Base unit 1024 (Flux standard)
+        switch (ar) {
+            case '1:1': return [1024, 1024];
+            case '16:9': return [1280, 720];
+            case '9:16': return [720, 1280];
+            case '4:3': return [1152, 864];
+            case '3:2': return [1216, 832];
+            case '21:9': return [1536, 640];
+            default: return [1024, 1024];
+        }
+    }
+}
+
+export const novita = new NovitaClient();

--- a/src/lib/novita.js
+++ b/src/lib/novita.js
@@ -1,5 +1,19 @@
 import { getNovitaImageModelById, getNovitaVideoModelById } from './models.js';
 
+const SUPPORTED_NOVITA_I2V_MODELS = new Set(['SVD', 'SVD-XT']);
+
+const dataUrlToBase64 = (dataUrl) => {
+    const parts = String(dataUrl).split(',');
+    return parts.length > 1 ? parts[1] : '';
+};
+
+const blobToBase64 = (blob) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(dataUrlToBase64(reader.result));
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+});
+
 export class NovitaClient {
     constructor() {
         this.baseUrl = 'https://api.novita.ai/v3/async';
@@ -7,7 +21,7 @@ export class NovitaClient {
 
     getKey() {
         const key = localStorage.getItem('novita_api_key');
-        if (!key) throw new Error('API Key missing. Please set it in Settings.');
+        if (!key) throw new Error('Novita API Key missing. Please set it in Settings.');
         return key;
     }
 
@@ -36,6 +50,32 @@ export class NovitaClient {
             payload.width = 2048;
             payload.height = 2048;
         }
+    }
+
+    normalizeResult(data, taskId = null) {
+        const imageUrl = data?.images?.[0]?.image_url;
+        const videoUrl = data?.videos?.[0]?.video_url;
+        const url = imageUrl || videoUrl || data?.url || null;
+        const outputs = url ? [url] : (data?.outputs || []);
+        return {
+            ...data,
+            id: taskId || data?.task?.task_id || data?.id,
+            request_id: taskId || data?.task?.task_id || data?.request_id,
+            url,
+            outputs
+        };
+    }
+
+    async convertImageUrlToBase64(imageUrl) {
+        if (!imageUrl) return null;
+        if (imageUrl.startsWith('data:')) return dataUrlToBase64(imageUrl);
+
+        const response = await fetch(imageUrl);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch source image: ${response.status}`);
+        }
+        const blob = await response.blob();
+        return blobToBase64(blob);
     }
 
     async submitTask(path, payload, key) {
@@ -83,7 +123,7 @@ export class NovitaClient {
             const data = await response.json();
             const status = data?.task?.status;
 
-            if (status === 'TASK_STATUS_SUCCEED') return data;
+            if (status === 'TASK_STATUS_SUCCEED') return this.normalizeResult(data, taskId);
             if (status === 'TASK_STATUS_FAILED') {
                 throw new Error(`Generation failed: ${data?.task?.reason || 'Unknown error'}`);
             }
@@ -95,7 +135,7 @@ export class NovitaClient {
     async generateImage(params) {
         const key = this.getKey();
         const modelInfo = getNovitaImageModelById(params.model);
-        const modelName = modelInfo?.endpoint || params.model;
+        const modelName = modelInfo?.endpoint || 'seedream-5.0-lite';
 
         const request = {
             model_name: modelName,
@@ -121,14 +161,13 @@ export class NovitaClient {
         if (params.onRequestId) params.onRequestId(taskId);
 
         const result = await this.pollTaskResult(taskId, key);
-        const imageUrl = result.images?.[0]?.image_url;
-        return { ...result, request_id: taskId, url: imageUrl };
+        return this.normalizeResult(result, taskId);
     }
 
     async generateVideo(params) {
         const key = this.getKey();
         const modelInfo = getNovitaVideoModelById(params.model);
-        const modelName = modelInfo?.endpoint || params.model;
+        const modelName = modelInfo?.endpoint || 'kling-v3.0-pro-t2v';
 
         let width = 1024;
         let height = 576;
@@ -144,7 +183,7 @@ export class NovitaClient {
             width,
             height,
             steps: params.steps || 20,
-            prompts: [{ frames, prompt: params.prompt }]
+            prompts: [{ frames, prompt: params.prompt || 'Generate a high quality video.' }]
         };
 
         if (params.negative_prompt) payload.negative_prompt = params.negative_prompt;
@@ -155,22 +194,22 @@ export class NovitaClient {
         if (params.onRequestId) params.onRequestId(taskId);
 
         const result = await this.pollTaskResult(taskId, key, 360, 2500);
-        const videoUrl = result.videos?.[0]?.video_url;
-        return { ...result, request_id: taskId, url: videoUrl };
+        return this.normalizeResult(result, taskId);
     }
 
     async generateI2I(params) {
-        if (!params.image_base64) {
-            throw new Error('Novita i2i requires image_base64 for /v3/async/img2img.');
+        const imageBase64 = params.image_base64 || await this.convertImageUrlToBase64(params.image_url);
+        if (!imageBase64) {
+            throw new Error('Novita i2i requires image_base64 or image_url.');
         }
 
         const key = this.getKey();
         const modelInfo = getNovitaImageModelById(params.model);
-        const modelName = modelInfo?.endpoint || params.model;
+        const modelName = modelInfo?.endpoint || 'seedream-5.0-lite';
 
         const request = {
             model_name: modelName,
-            image_base64: params.image_base64,
+            image_base64: imageBase64,
             prompt: params.prompt || '',
             width: 1024,
             height: 1024,
@@ -192,24 +231,54 @@ export class NovitaClient {
         if (params.onRequestId) params.onRequestId(taskId);
 
         const result = await this.pollTaskResult(taskId, key);
-        const imageUrl = result.images?.[0]?.image_url;
-        return { ...result, request_id: taskId, url: imageUrl };
+        return this.normalizeResult(result, taskId);
     }
 
-    async generateI2V() {
-        throw new Error('Novita i2v in this client is not implemented yet. Use txt2video or extend with /v3/async/img2video + base64.');
+    async generateI2V(params) {
+        const imageBase64 = params.image_base64 || await this.convertImageUrlToBase64(params.image_url);
+        if (!imageBase64) {
+            throw new Error('Novita i2v requires image_base64 or image_url.');
+        }
+
+        const key = this.getKey();
+        const modelName = SUPPORTED_NOVITA_I2V_MODELS.has(params.model) ? params.model : 'SVD-XT';
+
+        const payload = {
+            model_name: modelName,
+            image_file: imageBase64,
+            frames_num: modelName === 'SVD' ? 14 : 25,
+            frames_per_second: 6,
+            image_file_resize_mode: 'CROP_TO_ASPECT_RATIO',
+            steps: params.steps || 20
+        };
+        if (typeof params.seed === 'number') payload.seed = params.seed;
+
+        const taskId = await this.submitTask('img2video', payload, key);
+        if (params.onRequestId) params.onRequestId(taskId);
+
+        const result = await this.pollTaskResult(taskId, key, 360, 2500);
+        return this.normalizeResult(result, taskId);
     }
 
-    async uploadFile() {
-        throw new Error('Novita v3 media APIs require base64 inputs for i2i/i2v; uploadFile is not supported in this client.');
+    async uploadFile(file) {
+        if (!file || !file.type?.startsWith('image/')) {
+            throw new Error('Novita upload only supports image files in this adapter.');
+        }
+
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(String(reader.result));
+            reader.onerror = reject;
+            reader.readAsDataURL(file);
+        });
     }
 
     async processV2V() {
-        throw new Error('Novita v3 video-edit endpoint is not implemented yet in this client.');
+        throw new Error('Novita V2V is not implemented in this project yet. Please switch provider to Muapi for V2V.');
     }
 
     async processLipSync() {
-        throw new Error('Novita lipsync endpoint is not implemented yet in this client.');
+        throw new Error('Novita LipSync is not implemented in this project yet. Please switch provider to Muapi for LipSync.');
     }
 }
 

--- a/src/lib/providerConfig.js
+++ b/src/lib/providerConfig.js
@@ -1,0 +1,45 @@
+const ACTIVE_PROVIDER_KEY = 'active_provider';
+
+const PROVIDERS = {
+    muapi: {
+        id: 'muapi',
+        name: 'Muapi',
+        storageKey: 'muapi_key',
+        website: 'https://muapi.ai'
+    },
+    novita: {
+        id: 'novita',
+        name: 'Novita',
+        storageKey: 'novita_api_key',
+        website: 'https://novita.ai'
+    }
+};
+
+export const DEFAULT_PROVIDER = 'muapi';
+
+export const getProviders = () => Object.values(PROVIDERS);
+
+export const isValidProvider = (provider) => Boolean(PROVIDERS[provider]);
+
+export const getProviderMeta = (provider = DEFAULT_PROVIDER) => PROVIDERS[provider] || PROVIDERS[DEFAULT_PROVIDER];
+
+export const getProviderStorageKey = (provider = DEFAULT_PROVIDER) => getProviderMeta(provider).storageKey;
+
+export const getActiveProvider = () => {
+    const provider = localStorage.getItem(ACTIVE_PROVIDER_KEY) || DEFAULT_PROVIDER;
+    return isValidProvider(provider) ? provider : DEFAULT_PROVIDER;
+};
+
+export const setActiveProvider = (provider) => {
+    if (!isValidProvider(provider)) throw new Error(`Unknown provider: ${provider}`);
+    localStorage.setItem(ACTIVE_PROVIDER_KEY, provider);
+};
+
+export const getProviderApiKey = (provider = getActiveProvider()) => {
+    const storageKey = getProviderStorageKey(provider);
+    return localStorage.getItem(storageKey) || '';
+};
+
+export const hasProviderApiKey = (provider = getActiveProvider()) => Boolean(getProviderApiKey(provider));
+
+export const hasActiveProviderKey = () => hasProviderApiKey(getActiveProvider());

--- a/src/lib/providerRouter.js
+++ b/src/lib/providerRouter.js
@@ -1,0 +1,108 @@
+import { muapi } from './muapi.js';
+import { novita } from './novita.js';
+import { getActiveProvider, getProviderApiKey } from './providerConfig.js';
+
+const CAPABILITIES = {
+    muapi: {
+        generateImage: true,
+        generateVideo: true,
+        generateI2I: true,
+        generateI2V: true,
+        uploadFile: true,
+        processV2V: true,
+        processLipSync: true,
+        pollForResult: true
+    },
+    novita: {
+        generateImage: true,
+        generateVideo: true,
+        generateI2I: true,
+        generateI2V: true,
+        uploadFile: true,
+        processV2V: false,
+        processLipSync: false,
+        pollForResult: true
+    }
+};
+
+const getClient = () => {
+    const provider = getActiveProvider();
+    return provider === 'novita' ? novita : muapi;
+};
+
+const ensureCapability = (method) => {
+    const provider = getActiveProvider();
+    if (!CAPABILITIES[provider]?.[method]) {
+        throw new Error(`${provider} provider does not support ${method} in this project yet.`);
+    }
+};
+
+const normalizeResult = (res) => {
+    const url = res?.url || res?.outputs?.[0] || res?.output?.url || res?.images?.[0]?.image_url || res?.videos?.[0]?.video_url || null;
+    return {
+        ...res,
+        url,
+        outputs: res?.outputs || (url ? [url] : [])
+    };
+};
+
+export const api = {
+    getActiveProvider,
+    getCapabilities: () => CAPABILITIES[getActiveProvider()],
+
+    async pollForResult(requestId, _apiKey, maxAttempts, interval) {
+        ensureCapability('pollForResult');
+        const provider = getActiveProvider();
+
+        if (provider === 'novita') {
+            const key = getProviderApiKey('novita');
+            const res = await novita.pollTaskResult(requestId, key, maxAttempts, interval);
+            return normalizeResult(res);
+        }
+
+        const key = getProviderApiKey('muapi');
+        const res = await muapi.pollForResult(requestId, key, maxAttempts, interval);
+        return normalizeResult(res);
+    },
+
+    async generateImage(params) {
+        ensureCapability('generateImage');
+        const res = await getClient().generateImage(params);
+        return normalizeResult(res);
+    },
+
+    async generateVideo(params) {
+        ensureCapability('generateVideo');
+        const res = await getClient().generateVideo(params);
+        return normalizeResult(res);
+    },
+
+    async generateI2I(params) {
+        ensureCapability('generateI2I');
+        const res = await getClient().generateI2I(params);
+        return normalizeResult(res);
+    },
+
+    async generateI2V(params) {
+        ensureCapability('generateI2V');
+        const res = await getClient().generateI2V(params);
+        return normalizeResult(res);
+    },
+
+    async uploadFile(file) {
+        ensureCapability('uploadFile');
+        return getClient().uploadFile(file);
+    },
+
+    async processV2V(params) {
+        ensureCapability('processV2V');
+        const res = await getClient().processV2V(params);
+        return normalizeResult(res);
+    },
+
+    async processLipSync(params) {
+        ensureCapability('processLipSync');
+        const res = await getClient().processLipSync(params);
+        return normalizeResult(res);
+    }
+};


### PR DESCRIPTION
## Summary

This PR integrates **Novita** as an optional provider while keeping the existing **Muapi** architecture and default behavior unchanged.

Core direction:
- Keep Muapi as default provider (`active_provider=muapi`)
- Add a provider routing layer instead of rewriting existing business flows
- Ensure backward compatibility for existing component logic and local data

---

## What Changed

### 1) Non-breaking provider abstraction
- Added `src/lib/providerConfig.js`
  - Manages provider selection and API key storage:
    - `active_provider` (default: `muapi`)
    - `muapi_key`
    - `novita_api_key`
- Added `src/lib/providerRouter.js`
  - Exposes unified API entry (`api.*`) and routes calls to Muapi/Novita by active provider
  - Normalizes result shape (`url`, `outputs`, `request_id`)
  - Adds capability gating for unsupported provider features

### 2) Novita client corrected to official async media APIs
- Updated `src/lib/novita.js` to use Novita v3 async flow:
  - Base URL: `https://api.novita.ai/v3/async`
  - Submit async task (`txt2img`, `txt2video`, `img2img`, `img2video`)
  - Poll `task-result` with `task_id`
- Added result normalization and image base64 conversion helpers
- Current support in this project:
  - ✅ `generateImage`
  - ✅ `generateVideo`
  - ✅ `generateI2I`
  - ✅ `generateI2V`
  - ✅ `uploadFile` (image -> data URL for Novita flow)
  - ❌ `processV2V` (explicit unsupported error)
  - ❌ `processLipSync` (explicit unsupported error)

### 3) Components switched to unified router (minimal behavior changes)
- Updated to call `api.*` instead of `muapi.*` in:
  - `ImageStudio`
  - `VideoStudio`
  - `LipSyncStudio`
  - `CinemaStudio`
  - `UploadPicker`
- Existing generation UX and pending-job flow are preserved

### 4) Settings/Auth upgraded for dual provider keys
- `SettingsModal` now supports:
  - selecting active provider
  - storing both Muapi and Novita keys
- `AuthModal` now adapts copy/storage based on active provider

### 5) Build/runtime compatibility fix
- Updated `src/lib/muapi.js` constructor to avoid `import.meta.env` access issues in node-based module import checks

---

## Compatibility & Architecture Notes

- **No core Muapi logic rewrite**: Muapi client behavior remains intact and still powers default path.
- **No forced migration**: Existing users with `muapi_key` continue to work as before.
- **Provider extension ready**: Future providers can be added through router/config without touching component business logic.

---

## Verification

Executed locally:
- Module import checks (provider router / muapi / novita) passed
- `npm run build` passed successfully

Build note:
- Existing non-blocking Vite warning remains (`SettingsModal` dynamic + static import in different paths)

---

## Known Limitations (current scope)

For Novita provider in this project:
- `processV2V` and `processLipSync` are not implemented yet
- Router returns explicit capability error instead of silent failure