### PR TITLE
feat(image-studio): wire up batch size 1–4 for image generation (closes #69)

### DIFF
--- a/packages/studio/src/components/ImageStudio.jsx
+++ b/packages/studio/src/components/ImageStudio.jsx
@@ -733,6 +733,8 @@ export default function ImageStudio({
     return resolutions[0] || null;
   });
   const [maxImages, setMaxImages] = useState(1);
+  // Number of images to generate in parallel per "Generate" click (1..4).
+  const [batchCount, setBatchCount] = useState(1);
 
   // ── Prompt / upload state ───────────────────────────────────────────────
   const [prompt, setPrompt] = useState("");
@@ -781,6 +783,7 @@ export default function ImageStudio({
         if (data.selectedAr) setSelectedAr(data.selectedAr);
         if (data.selectedQuality) setSelectedQuality(data.selectedQuality);
         if (data.maxImages) setMaxImages(data.maxImages);
+        if (data.batchCount) setBatchCount(data.batchCount);
         if (data.prompt) setPrompt(data.prompt);
         if (data.uploadedImageUrls) setUploadedImageUrls(data.uploadedImageUrls);
         if (data.localHistory) setLocalHistory(data.localHistory);
@@ -801,6 +804,7 @@ export default function ImageStudio({
           selectedAr,
           selectedQuality,
           maxImages,
+          batchCount,
           prompt,
           uploadedImageUrls,
           localHistory,
@@ -818,6 +822,7 @@ export default function ImageStudio({
     selectedAr,
     selectedQuality,
     maxImages,
+    batchCount,
     prompt,
     uploadedImageUrls,
     localHistory,
@@ -942,8 +947,11 @@ export default function ImageStudio({
     setGenerating(true);
     setGenerateError(null);
 
-    try {
-      let res;
+    const count = Math.max(1, Math.min(4, parseInt(batchCount, 10) || 1));
+    const trimmedPrompt = prompt.trim();
+
+    // Build params once; each slot reuses the same payload (seed is left random).
+    const buildParams = () => {
       if (imageMode) {
         const genParams = {
           model: selectedModelId,
@@ -951,28 +959,48 @@ export default function ImageStudio({
           image_url: uploadedImageUrls[0],
           aspect_ratio: selectedAr,
         };
-        if (prompt.trim()) genParams.prompt = prompt.trim();
+        if (trimmedPrompt) genParams.prompt = trimmedPrompt;
         if (currentQualityField && selectedQuality) {
           genParams[currentQualityField] = selectedQuality;
         }
-        res = await generateI2I(apiKey, genParams);
-      } else {
-        const genParams = {
-          model: selectedModelId,
-          prompt: prompt.trim(),
-          aspect_ratio: selectedAr,
-        };
-        if (currentQualityField && selectedQuality) {
-          genParams[currentQualityField] = selectedQuality;
-        }
-        res = await generateImage(apiKey, genParams);
+        return genParams;
+      }
+      const genParams = {
+        model: selectedModelId,
+        prompt: trimmedPrompt,
+        aspect_ratio: selectedAr,
+      };
+      if (currentQualityField && selectedQuality) {
+        genParams[currentQualityField] = selectedQuality;
+      }
+      return genParams;
+    };
+
+    try {
+      // Run all batch slots in parallel. Each call returns its own image URL
+      // (the API doesn't expose a server-side batch option on the /v1 endpoints,
+      // so we fan out client-side and treat each response as an independent item).
+      const results = await Promise.allSettled(
+        Array.from({ length: count }, () =>
+          imageMode ? generateI2I(apiKey, buildParams()) : generateImage(apiKey, buildParams()),
+        ),
+      );
+
+      const successes = results
+        .filter((r) => r.status === "fulfilled" && r.value && r.value.url)
+        .map((r) => r.value);
+
+      if (successes.length === 0) {
+        const firstRejection = results.find((r) => r.status === "rejected");
+        const err = firstRejection?.reason;
+        throw err instanceof Error ? err : new Error("No image URL returned by API");
       }
 
-      if (res && res.url) {
+      successes.forEach((res, i) => {
         const entry = {
-          id: res.id || Date.now().toString(),
+          id: res.id || `${Date.now()}-${i}`,
           url: res.url,
-          prompt: prompt.trim(),
+          prompt: trimmedPrompt,
           model: selectedModelId,
           aspect_ratio: selectedAr,
           timestamp: new Date().toISOString(),
@@ -981,11 +1009,14 @@ export default function ImageStudio({
         onGenerationComplete?.({
           url: res.url,
           model: selectedModelId,
-          prompt: prompt.trim(),
+          prompt: trimmedPrompt,
           type: "image",
         });
-      } else {
-        throw new Error("No image URL returned by API");
+      });
+
+      const failureCount = results.length - successes.length;
+      if (failureCount > 0) {
+        console.warn(`[ImageStudio] ${failureCount}/${count} batch slot(s) failed`);
       }
     } catch (e) {
       console.error("[ImageStudio] Generation failed:", e);
@@ -1254,6 +1285,44 @@ export default function ImageStudio({
                   )}
                 </div>
               )}
+
+              {/* Batch count button (1–4 images per generation) */}
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setDropdownOpen((o) => (o === "batch" ? null : "batch"));
+                  }}
+                  title="Number of images per generation"
+                  className="flex items-center gap-2 px-3 py-2 bg-white/[0.03] hover:bg-white/[0.06] rounded-md transition-all border border-white/[0.03] group whitespace-nowrap"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="opacity-40 text-white">
+                    <rect x="3" y="3" width="7" height="7" rx="1" />
+                    <rect x="14" y="3" width="7" height="7" rx="1" />
+                    <rect x="3" y="14" width="7" height="7" rx="1" />
+                    <rect x="14" y="14" width="7" height="7" rx="1" />
+                  </svg>
+                  <span className="text-[11px] font-semibold text-white/70 group-hover:text-[#d9ff00] transition-colors">
+                    x{batchCount}
+                  </span>
+                </button>
+
+                {dropdownOpen === "batch" && (
+                  <div
+                    onClick={(e) => e.stopPropagation()}
+                    className="absolute bottom-[calc(100%+12px)] left-0 z-50 bg-[#0a0a0a] rounded-md p-3 shadow-2xl border border-white/[0.05] min-w-[140px]"
+                  >
+                    <SimpleDropdown
+                      title="Batch Size"
+                      options={[1, 2, 3, 4]}
+                      selected={batchCount}
+                      onSelect={(val) => setBatchCount(val)}
+                      onClose={() => setDropdownOpen(null)}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Generate button */}

--- a/src/components/ImageStudio.js
+++ b/src/components/ImageStudio.js
@@ -844,9 +844,9 @@ export function ImageStudio() {
     const imageContainer = document.createElement('div');
     imageContainer.className = 'relative group';
 
-    const resultImg = document.createElement('img');
-    resultImg.className = 'max-h-[60vh] max-w-[80vw] rounded-3xl shadow-3xl border border-white/10 interactive-glow object-contain';
-    imageContainer.appendChild(resultImg);
+    // Tracks the URL currently featured in the canvas (used by the Download button
+    // and to know which image out of a batch the user has selected).
+    let currentCanvasUrl = null;
 
     // Canvas Controls
     const canvasControls = document.createElement('div');
@@ -872,20 +872,55 @@ export function ImageStudio() {
     canvas.appendChild(canvasControls);
     container.appendChild(canvas);
 
-    // --- Helper: Show image in canvas ---
-    const showImageInCanvas = (imageUrl) => {
+    // --- Helper: Reveal the canvas once the first image has loaded ---
+    const revealCanvas = () => {
+        canvas.classList.remove('opacity-0', 'pointer-events-none', 'translate-y-10', 'scale-95');
+        canvas.classList.add('opacity-100', 'translate-y-0', 'scale-100');
+        canvasControls.classList.remove('opacity-0');
+        canvasControls.classList.add('opacity-100');
+    };
+
+    // --- Helper: Show one or many images in the canvas ---
+    // A single URL renders as before (big featured image). Multiple URLs render as
+    // a responsive grid where each tile can be clicked to expand to full size.
+    const showImagesInCanvas = (imageUrls) => {
+        const urls = Array.isArray(imageUrls) ? imageUrls : [imageUrls];
+        if (urls.length === 0) return;
+
         // Fully hide hero and prompt
         hero.classList.add('hidden');
         promptWrapper.classList.add('hidden');
 
-        resultImg.src = imageUrl;
-        resultImg.onload = () => {
-            canvas.classList.remove('opacity-0', 'pointer-events-none', 'translate-y-10', 'scale-95');
-            canvas.classList.add('opacity-100', 'translate-y-0', 'scale-100');
-            canvasControls.classList.remove('opacity-0');
-            canvasControls.classList.add('opacity-100');
-        };
+        imageContainer.innerHTML = '';
+        currentCanvasUrl = urls[0];
+
+        if (urls.length === 1) {
+            const img = document.createElement('img');
+            img.className = 'max-h-[60vh] max-w-[80vw] rounded-3xl shadow-3xl border border-white/10 interactive-glow object-contain';
+            img.src = urls[0];
+            img.onload = revealCanvas;
+            imageContainer.appendChild(img);
+        } else {
+            // Up to 4 images — render as a 2-column grid (2x1 for 2, 2x2 for 3–4).
+            const grid = document.createElement('div');
+            grid.className = 'grid grid-cols-2 gap-3 md:gap-4 max-h-[70vh]';
+            urls.forEach((u, i) => {
+                const tile = document.createElement('img');
+                tile.className = 'max-h-[32vh] max-w-[38vw] rounded-2xl shadow-2xl border border-white/10 object-contain cursor-pointer hover:scale-[1.02] hover:border-primary/50 transition-all';
+                tile.src = u;
+                if (i === 0) tile.onload = revealCanvas;
+                tile.onclick = () => showImagesInCanvas([u]);
+                tile.title = 'Click to expand';
+                grid.appendChild(tile);
+            });
+            imageContainer.appendChild(grid);
+            // Fallback reveal in case the first image is cached and onload already fired
+            revealCanvas();
+        }
     };
+
+    // Backward-compatible single-image wrapper
+    const showImageInCanvas = (imageUrl) => showImagesInCanvas([imageUrl]);
 
     // --- Helper: Add to history ---
     const addToHistory = (entry) => {
@@ -1001,7 +1036,7 @@ export function ImageStudio() {
 
     // --- Button Handlers ---
     downloadBtn.onclick = () => {
-        const current = resultImg.src;
+        const current = currentCanvasUrl;
         if (current) {
             const entry = generationHistory.find(e => e.url === current);
             downloadImage(current, `muapi-${entry?.id || 'image'}.jpg`);
@@ -1064,65 +1099,119 @@ export function ImageStudio() {
 
         hero.classList.add('opacity-0', 'scale-95', '-translate-y-10', 'pointer-events-none');
         generateBtn.disabled = true;
-        generateBtn.innerHTML = `<span class="animate-spin inline-block mr-2 text-black">◌</span> Generating...`;
 
-        let hadError = false;
-        let capturedRequestId = null;
+        // Clamp batch count to the slider's configured range as a defensive guard.
+        const count = Math.max(1, Math.min(4, parseInt(batchCount, 10) || 1));
+        const updateBtnProgress = (done) => {
+            const label = count > 1 ? `Generating ${done}/${count}...` : 'Generating...';
+            generateBtn.innerHTML = `<span class="animate-spin inline-block mr-2 text-black">◌</span> ${label}`;
+        };
+        updateBtnProgress(0);
+
         const historyMeta = { prompt, model: selectedModel, aspect_ratio: selectedAr };
+        const qualityLabel = document.getElementById('quality-btn-label')?.textContent;
+        const qualityField = getCurrentQualityField(selectedModel);
 
-        try {
-            let res;
-            const qualityLabel = document.getElementById('quality-btn-label')?.textContent;
+        // Build one set of generation params for a single slot in the batch.
+        // Each slot tracks its own requestId so pending jobs can be individually
+        // cleared (or resumed on reload) without one failure affecting the others.
+        const buildSlot = (slotIdx) => {
+            const slot = { requestId: null };
+            const onRequestId = (rid) => {
+                slot.requestId = rid;
+                savePendingJob({
+                    requestId: rid,
+                    studioType: 'image',
+                    historyMeta,
+                    maxAttempts: 60,
+                    interval: 2000,
+                    submittedAt: Date.now()
+                });
+            };
+
+            let genParams;
             if (imageMode) {
-                const genParams = {
+                genParams = {
                     model: selectedModel,
                     images_list: uploadedImageUrls,
                     image_url: uploadedImageUrls[0], // backward compat for single-image models
                     aspect_ratio: selectedAr,
-                    onRequestId: (rid) => {
-                        capturedRequestId = rid;
-                        savePendingJob({ requestId: rid, studioType: 'image', historyMeta, maxAttempts: 60, interval: 2000, submittedAt: Date.now() });
-                    }
+                    onRequestId
                 };
                 if (prompt) genParams.prompt = prompt;
-                const qualityField = getCurrentQualityField(selectedModel);
-                if (qualityField && qualityLabel) genParams[qualityField] = qualityLabel;
-                res = await muapi.generateI2I(genParams);
             } else {
-                const genParams = {
+                genParams = {
                     model: selectedModel,
                     prompt,
                     aspect_ratio: selectedAr,
-                    onRequestId: (rid) => {
-                        capturedRequestId = rid;
-                        savePendingJob({ requestId: rid, studioType: 'image', historyMeta, maxAttempts: 60, interval: 2000, submittedAt: Date.now() });
-                    }
+                    onRequestId
                 };
-                const qualityField = getCurrentQualityField(selectedModel);
-                if (qualityField && qualityLabel) genParams[qualityField] = qualityLabel;
-                res = await muapi.generateImage(genParams);
+            }
+            if (qualityField && qualityLabel) genParams[qualityField] = qualityLabel;
+
+            // When the user has pinned a specific seed we offset it per slot so the
+            // batch yields distinct variations rather than 4 identical images.
+            // A seed of -1 means "random" and is left alone for each call.
+            if (typeof seed === 'number' && seed !== -1) {
+                genParams.seed = seed + slotIdx;
             }
 
-            console.log('[ImageStudio] Full response:', res);
+            slot.params = genParams;
+            return slot;
+        };
 
-            if (res && res.url) {
-                if (capturedRequestId) removePendingJob(capturedRequestId);
+        const slots = Array.from({ length: count }, (_, i) => buildSlot(i));
+
+        // Kick off all slots in parallel and report progress as each one finishes.
+        let completed = 0;
+        const runSlot = async (slot) => {
+            try {
+                const res = imageMode
+                    ? await muapi.generateI2I(slot.params)
+                    : await muapi.generateImage(slot.params);
+                if (slot.requestId) removePendingJob(slot.requestId);
+                if (!res || !res.url) throw new Error('No image URL returned by API');
+                return { ok: true, res, slot };
+            } catch (err) {
+                if (slot.requestId) removePendingJob(slot.requestId);
+                return { ok: false, error: err, slot };
+            } finally {
+                completed++;
+                updateBtnProgress(completed);
+            }
+        };
+
+        let hadError = false;
+        try {
+            const results = await Promise.all(slots.map(runSlot));
+            const successes = results.filter(r => r.ok);
+            const failures = results.filter(r => !r.ok);
+
+            if (successes.length === 0) {
+                const firstErr = failures[0]?.error;
+                throw firstErr instanceof Error ? firstErr : new Error('All generations failed');
+            }
+
+            const urls = successes.map(r => {
+                const { res, slot } = r;
                 addToHistory({
-                    id: res.id || capturedRequestId || Date.now().toString(),
+                    id: res.id || slot.requestId || `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
                     url: res.url,
                     prompt: prompt,
                     model: selectedModel,
                     aspect_ratio: selectedAr,
                     timestamp: new Date().toISOString()
                 });
-                showImageInCanvas(res.url);
-            } else {
-                console.error('[ImageStudio] No image URL in response:', res);
-                throw new Error('No image URL returned by API');
+                return res.url;
+            });
+
+            showImagesInCanvas(urls);
+
+            if (failures.length > 0) {
+                console.warn(`[ImageStudio] ${failures.length}/${count} batch slot(s) failed:`, failures.map(f => f.error?.message));
             }
         } catch (e) {
             hadError = true;
-            if (capturedRequestId) removePendingJob(capturedRequestId);
             console.error(e);
             // Restore hero so the page doesn't look broken after a failed generation
             hero.classList.remove('opacity-0', 'scale-95', '-translate-y-10', 'pointer-events-none');


### PR DESCRIPTION
## Summary

Closes #69 — adds working **batch generation of 1–4 images per click** in both the Vite/Electron studio (where a batch slider already existed but was wired to nothing) and the Next.js studio (which had no batch UI).

### What changed

**`src/components/ImageStudio.js`** (Vite/Electron)
- The existing "Batch Count" slider (1–4) was reading into a `batchCount` variable that was never passed to the request, so every click produced a single image. `batchCount` is now actually used.
- The generate handler fans out `N` parallel calls (one per batch slot). Each slot keeps its own `request_id` via `savePendingJob` / `removePendingJob`, so pending-job resume on reload and partial failures work correctly per-image — if one slot fails, the others still resolve.
- When the user pins a non-random seed, each slot uses `seed + i` so the batch yields distinct variations instead of four identical images. A seed of `-1` (random) is left alone.
- The single `resultImg` was replaced with a dynamic image container: one image renders full-size as before; 2–4 images render as a 2-column grid where each tile is clickable to expand to full size. The Download button now targets the currently selected URL.
- Button label shows `Generating 2/4…` style progress while the batch is in flight.

**`packages/studio/src/components/ImageStudio.jsx`** (Next.js studio)
- Added a `batchCount` state (persisted alongside the other studio prefs in `hg_image_studio_persistent`).
- Added a compact `x1 / x2 / x3 / x4` dropdown button in the existing control row, styled to match the aspect-ratio / quality buttons.
- Refactored `handleGenerate` to run the requested number of calls via `Promise.allSettled`, push each successful result into history, call `onGenerationComplete` per result, and only surface an error if **all** slots failed. The existing gallery grid naturally renders the new entries, so no separate canvas work was needed on this side.

### Why client-side fan-out

The Muapi `/api/v1/*` generation endpoints don't expose a server-side batch / `num_outputs` parameter — each request returns a single image. Fanning out on the client is the simplest way to support batches without touching the API client or backend contract, and it keeps per-image polling, request-id tracking, and error handling independent.

### Notes for review

- No API contract changes. No new dependencies. No migration needed.
- The `batchCount` range matches the slider that was already in the UI (1–4), so expectations don't shift for existing users.
- If any slot fails but others succeed, the UI now shows the successful images and logs the failures to console rather than throwing away the whole batch. Throwing only happens when every slot fails.
- The Vite build (`npx vite build`) passes. The Next.js build (`npm run build`) is blocked in my environment by an unrelated pre-existing issue — the `packages/workflow-ui` git submodule points at a repo that currently returns 404 on clone — but this affects only `WorkflowUI.jsx`, which is untouched here, and the edited `ImageStudio.jsx` parses cleanly against `@babel/parser` with the `jsx` plugin.

## Test plan

- [ ] Open the image studio, set batch = 1, generate — behaves identically to before (single featured image, single history entry, download works).
- [ ] Set batch = 4, generate — four parallel requests go out, all four images land in history, the canvas shows a 2×2 grid, clicking a tile expands it, Download targets the expanded one.
- [ ] Set a fixed seed in the advanced panel (Vite/Electron), batch = 4 — the four images are visibly different (seed offset per slot), not duplicates.
- [ ] Leave seed at -1 (random), batch = 4 — each image is different (each call is independently random).
- [ ] Force a failure on one slot (e.g. flaky network for one request) — the remaining successful images still render and are added to history; only a warning is logged for the failed slot.
- [ ] Refresh mid-batch — `savePendingJob` / `removePendingJob` correctly track each slot; the "Resuming N pending generation(s)" banner picks them up individually.
- [ ] In the Next.js studio, confirm the new `x1..x4` batch dropdown appears in the control row and persists across reloads.