### PR TITLE
feat: add Docker support with port conflict avoidance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+
+# Install dependencies
+FROM base AS deps
+COPY package*.json ./
+COPY packages/Vibe-Workflow/packages/workflow-builder/package*.json ./packages/Vibe-Workflow/packages/workflow-builder/
+COPY packages/Open-Poe-AI/packages/agents/package*.json ./packages/Open-Poe-AI/packages/agents/
+COPY packages/studio/package*.json ./packages/studio/
+RUN npm install
+
+# Build sub-packages
+FROM deps AS builder
+COPY . .
+RUN npm run build:packages
+RUN npm run build
+
+# Production runner
+FROM base AS runner
+ENV NODE_ENV=production
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  open-generative-ai:
+    build: .
+    container_name: open-generative-ai
+    ports:
+      - "3001:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` to build and run the Next.js app in a container
- Add `docker-compose.yml` for one-command startup
- Map host port **3001 → container 3000** to avoid conflict with the local dev server running on port 3000

## How to run

```bash
docker compose up --build
```

App will be available at **http://localhost:3001**

## Reviewer notes

- Multi-stage build: `deps` → `builder` → `runner` (production image only ships compiled output)
- Sub-packages (`workflow-builder`, `ai-agent`, `studio`) are built inside the container via `npm run build:packages` before `next build`
- `restart: unless-stopped` policy in compose for production use

🤖 Generated with [Claude Code](https://claude.com/claude-code)