### PR TITLE
fix: inject NEXT_PUBLIC_MUAPI_KEY into window.__MUAPI_KEY__ at page load

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -12,8 +12,18 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }) {
+  const apiKey = process.env.NEXT_PUBLIC_MUAPI_KEY || '';
   return (
     <html lang="en">
+      <head>
+        {apiKey && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.__MUAPI_KEY__ = ${JSON.stringify(apiKey)};`,
+            }}
+          />
+        )}
+      </head>
       <body className={inter.variable}>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Summary

- The studio client reads the API key from `window.__MUAPI_KEY__` or `localStorage`, but `NEXT_PUBLIC_MUAPI_KEY` (set in `.env.local`) was never wired to either
- In private/incognito sessions where `localStorage` is empty, requests were sent without an API key, causing the API to return unrelated results
- This fix injects the env variable server-side in the root layout so the key is always available before any client code runs

## What changed

`app/layout.js` — reads `process.env.NEXT_PUBLIC_MUAPI_KEY` and injects it as `window.__MUAPI_KEY__` via a `<script>` tag in `<head>`. The injection only happens when the env var is set, so it's fully backwards compatible for deployments without it.

## Test plan

- [ ] Set `NEXT_PUBLIC_MUAPI_KEY` in `.env.local`
- [ ] Open the app in a private/incognito window (empty localStorage)
- [ ] Verify the studio loads directly without showing the API key modal
- [ ] Verify image/video generation works and matches the prompt