### PR TITLE
Fix upload proxy safety checks

### DIFF
--- a/app/api/_utils/uploadProxyToken.js
+++ b/app/api/_utils/uploadProxyToken.js
@@ -1,0 +1,106 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+const TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const GLOBAL_FALLBACK_SECRET_KEY = '__UPLOAD_PROXY_FALLBACK_SECRET__';
+
+function getFallbackSecret() {
+    if (!globalThis[GLOBAL_FALLBACK_SECRET_KEY]) {
+        globalThis[GLOBAL_FALLBACK_SECRET_KEY] = randomBytes(32).toString('hex');
+    }
+    return globalThis[GLOBAL_FALLBACK_SECRET_KEY];
+}
+
+function getTokenSecret() {
+    // In distributed/serverless deployments, set UPLOAD_PROXY_SECRET (or
+    // MUAPI_UPLOAD_PROXY_SECRET) so tokens can be verified across instances.
+    return (
+        process.env.UPLOAD_PROXY_SECRET ||
+        process.env.MUAPI_UPLOAD_PROXY_SECRET ||
+        process.env.NEXTAUTH_SECRET ||
+        getFallbackSecret()
+    );
+}
+
+function sign(input) {
+    return createHmac('sha256', getTokenSecret()).update(input).digest('base64url');
+}
+
+function safeJsonParse(input) {
+    try {
+        return JSON.parse(input);
+    } catch {
+        return null;
+    }
+}
+
+// Allow only HTTPS S3-style upload endpoints.
+function isAllowedS3Host(hostname) {
+    const host = hostname.toLowerCase();
+
+    // Common S3 endpoint families:
+    // - s3.amazonaws.com
+    // - bucket.s3.amazonaws.com
+    // - s3.<region>.amazonaws.com
+    // - bucket.s3.<region>.amazonaws.com
+    // - s3-<region>.amazonaws.com
+    // - bucket.s3-<region>.amazonaws.com
+    // - *.s3-accelerate.amazonaws.com
+    const s3Pattern = /(^|\.)(s3|s3-[a-z0-9-]+|s3\.[a-z0-9-]+|s3-accelerate)(\.dualstack)?\.amazonaws\.com$/i;
+    const s3ChinaPattern = /(^|\.)(s3|s3-[a-z0-9-]+|s3\.[a-z0-9-]+|s3-accelerate)(\.dualstack)?\.amazonaws\.com\.cn$/i;
+    return s3Pattern.test(host) || s3ChinaPattern.test(host);
+}
+
+export function isAllowedUploadTarget(rawUrl) {
+    if (typeof rawUrl !== 'string' || rawUrl.length > 2048) return false;
+
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        return false;
+    }
+
+    if (parsed.protocol !== 'https:') return false;
+    if (parsed.username || parsed.password) return false;
+    if (!isAllowedS3Host(parsed.hostname)) return false;
+
+    return true;
+}
+
+export function issueUploadProxyToken(targetUrl) {
+    if (!isAllowedUploadTarget(targetUrl)) {
+        throw new Error('Refusing to issue upload token for an invalid target URL');
+    }
+
+    const payload = {
+        u: targetUrl,
+        exp: Date.now() + TOKEN_TTL_MS,
+    };
+
+    const payloadB64 = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+    const sig = sign(payloadB64);
+    return `${payloadB64}.${sig}`;
+}
+
+export function parseUploadProxyToken(token) {
+    if (typeof token !== 'string') return null;
+
+    const parts = token.split('.');
+    if (parts.length !== 2) return null;
+
+    const [payloadB64, sig] = parts;
+    const expectedSig = sign(payloadB64);
+
+    const sigBuf = Buffer.from(sig, 'utf8');
+    const expectedSigBuf = Buffer.from(expectedSig, 'utf8');
+    if (sigBuf.length !== expectedSigBuf.length) return null;
+    if (!timingSafeEqual(sigBuf, expectedSigBuf)) return null;
+
+    const payloadJson = Buffer.from(payloadB64, 'base64url').toString('utf8');
+    const payload = safeJsonParse(payloadJson);
+    if (!payload || typeof payload.u !== 'string' || typeof payload.exp !== 'number') return null;
+    if (Date.now() > payload.exp) return null;
+    if (!isAllowedUploadTarget(payload.u)) return null;
+
+    return payload.u;
+}

--- a/app/api/app/[[...path]]/route.js
+++ b/app/api/app/[[...path]]/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { issueUploadProxyToken } from '../../_utils/uploadProxyToken';
 
 const MUAPI_BASE = 'https://api.muapi.ai';
 
@@ -47,14 +48,17 @@ export async function GET(request, { params }) {
         // SPECIAL CASE: Intercept upload URL and redirect to local binary proxy
         if (effectivePath === 'get_file_upload_url' && data.url) {
             const originalS3Url = data.url;
-            // We pass the real S3 URL as a header to our proxy
+            const uploadProxyToken = issueUploadProxyToken(originalS3Url);
+
             data.url = `/api/upload-binary`;
-            
-            // Store target in a temporary way? 
-            // Better: Return the target URL as an extra field that our proxy will look for
             data.fields = {
                 ...data.fields,
-                'x-proxy-target-url': originalS3Url
+                // Private field consumed by /api/upload-binary.
+                // Contains a short-lived signed token, not the raw destination URL.
+                'x-proxy-upload-token': uploadProxyToken,
+                // Compatibility + resiliency fallback.
+                // /api/upload-binary still validates this against a strict S3 allowlist.
+                'x-proxy-target-url': originalS3Url,
             };
         }
 

--- a/app/api/upload-binary/route.js
+++ b/app/api/upload-binary/route.js
@@ -1,14 +1,27 @@
 import { NextResponse } from 'next/server';
+import { isAllowedUploadTarget, parseUploadProxyToken } from '../_utils/uploadProxyToken';
 
 export async function POST(request) {
     try {
         const formData = await request.formData();
-        
-        // Extract the original S3 target URL we injected earlier
-        const targetUrl = formData.get('x-proxy-target-url');
-        
+
+        const uploadProxyToken = formData.get('x-proxy-upload-token');
+        let targetUrl = parseUploadProxyToken(uploadProxyToken);
+
+        // Backward-compatible path for older clients that still send the raw field.
+        // Keep strict validation so this path cannot be abused as an open proxy.
         if (!targetUrl) {
-            return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
+            const legacyTarget = formData.get('x-proxy-target-url');
+            if (typeof legacyTarget === 'string' && isAllowedUploadTarget(legacyTarget)) {
+                targetUrl = legacyTarget;
+            }
+        }
+
+        if (!targetUrl) {
+            return NextResponse.json(
+                { error: 'Invalid or missing upload proxy token/target URL' },
+                { status: 400 }
+            );
         }
 
         // Reconstruct the FormData for S3 (excluding our internal proxy marker)
@@ -18,7 +31,7 @@ export async function POST(request) {
         // or at least that all signature fields come before what S3 expects.
         // The original library code appends 'file' last, so iterating should preserve that.
         for (const [key, value] of formData.entries()) {
-            if (key !== 'x-proxy-target-url') {
+            if (key !== 'x-proxy-target-url' && key !== 'x-proxy-upload-token') {
                 s3FormData.append(key, value);
             }
         }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:workflow": "npm run build -w workflow-builder",
     "build:agent": "npm run build -w ai-agent",
     "build:packages": "npm run build:workflow && npm run build:agent && npm run build:studio",
+    "verify:upload-proxy": "node scripts/verify_upload_proxy_security.mjs",
     "setup": "git submodule update --init --recursive && npm install && npm run build:packages",
     "vite:dev": "vite",
     "vite:build": "vite build",

--- a/scripts/verify_upload_proxy_security.mjs
+++ b/scripts/verify_upload_proxy_security.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import {
+    isAllowedUploadTarget,
+    issueUploadProxyToken,
+    parseUploadProxyToken,
+} from '../app/api/_utils/uploadProxyToken.js';
+
+function expectAllowed(url) {
+    assert.equal(isAllowedUploadTarget(url), true, `Expected allowed URL: ${url}`);
+}
+
+function expectBlocked(url) {
+    assert.equal(isAllowedUploadTarget(url), false, `Expected blocked URL: ${url}`);
+}
+
+// Expected valid S3 endpoint patterns.
+expectAllowed('https://s3.amazonaws.com/my-bucket');
+expectAllowed('https://my-bucket.s3.amazonaws.com/my/key');
+expectAllowed('https://my-bucket.s3.us-east-1.amazonaws.com/my/key');
+expectAllowed('https://my-bucket.s3-us-west-2.amazonaws.com/my/key');
+expectAllowed('https://my-bucket.s3-accelerate.amazonaws.com/my/key');
+
+// Must reject non-HTTPS and non-S3 destinations.
+expectBlocked('http://my-bucket.s3.amazonaws.com/my/key');
+expectBlocked('https://example.com/upload');
+expectBlocked('https://169.254.169.254/latest/meta-data');
+expectBlocked('https://localhost:9000/upload');
+expectBlocked('https://my-bucket.s3.amazonaws.com.evil.com/upload');
+expectBlocked('not-a-url');
+
+// Signed token round-trip.
+const target = 'https://my-bucket.s3.us-east-1.amazonaws.com/upload';
+const token = issueUploadProxyToken(target);
+assert.equal(typeof token, 'string');
+assert.equal(parseUploadProxyToken(token), target, 'Expected valid token to decode original target');
+
+// Tampering must fail.
+assert.equal(parseUploadProxyToken(token + 'x'), null, 'Expected tampered token to fail validation');
+
+const [payloadPart, sigPart] = token.split('.');
+const tamperedPayload = Buffer.from(
+    JSON.stringify({ u: 'https://example.com/upload', exp: Date.now() + 60_000 }),
+    'utf8'
+).toString('base64url');
+assert.equal(parseUploadProxyToken(`${tamperedPayload}.${sigPart}`), null, 'Expected payload tampering to fail');
+
+// Expired token must fail.
+const payload = JSON.parse(Buffer.from(payloadPart, 'base64url').toString('utf8'));
+payload.exp = Date.now() - 1;
+const expiredPayloadPart = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+assert.equal(parseUploadProxyToken(`${expiredPayloadPart}.${sigPart}`), null, 'Expected expired token to fail');
+
+// Legacy target field validation must still block SSRF/private targets.
+assert.equal(isAllowedUploadTarget('http://169.254.169.254/latest/meta-data'), false);
+assert.equal(isAllowedUploadTarget('https://localhost/upload'), false);
+
+console.log('Upload proxy security checks passed.');


### PR DESCRIPTION
Fixes #162

This PR fixes a security gap in the upload proxy.

## What changed
- added strict upload target validation (HTTPS + S3 endpoint patterns)
- added signed short-lived upload token support
- reject invalid or unsafe target metadata with HTTP 400
- kept backward compatibility while still validating fallback target input
- added a small verification script: `npm run verify:upload-proxy`

## Why
Previously, upload target metadata could be influenced by client-submitted data. This could allow unsafe server-side forwarding behavior in exposed/self-hosted setups.

## Validation
- `npm run verify:upload-proxy` passes
- live route behavior checked:
  - invalid target is blocked
  - valid signed token path is accepted and forwarded upstream
