### PR TITLE
[codex] Add bundled local inference packaging for Linux builds

### DIFF
--- a/build/local-ai/README.md
+++ b/build/local-ai/README.md
@@ -1,0 +1,8 @@
+Stage packaged local inference binaries here before running Electron builds.
+
+Examples:
+- `npm run stage:local-ai -- linux arm64 /path/to/stable-diffusion.cpp/build-cuda-arm64`
+- `npm run stage:local-ai -- linux x64 /path/to/stable-diffusion.cpp/build/bin`
+
+This copies the expected runtime files into `build/local-ai/<platform>-<arch>/bin`,
+which Electron Builder then bundles into `resources/local-ai/...` via `extraResources`.

--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -8,6 +8,11 @@ const {
     getBundledBinaryResourceDir,
     pickBinaryAssetForPlatform,
 } = require('./localInferenceAssets');
+const {
+    parseGenerationProgressChunk,
+    resolveGenerationSteps,
+    resolveGuidanceScale,
+} = require('./localInferenceRuntime');
 
 // ─── Paths ────────────────────────────────────────────────────────────────────
 const DATA_DIR = path.join(app.getPath('userData'), 'local-ai');
@@ -414,8 +419,8 @@ async function generate(params, mainWindow) {
     const seed = params.seed && params.seed !== -1 ? params.seed : Math.floor(Math.random() * 2147483647);
     const outPath = path.join(TMP_DIR, `gen-${Date.now()}.png`);
 
-    const steps = model.defaultSteps || params.steps || 20;
-    const cfgScale = model.defaultGuidance !== undefined ? model.defaultGuidance : (params.guidance_scale || 7.5);
+    const steps = resolveGenerationSteps(params, model);
+    const cfgScale = resolveGuidanceScale(params, model);
     const sampler = model.sampler || 'euler_a';
 
     // z-image GGUFs are standalone diffusion transformers loaded via --diffusion-model.
@@ -456,23 +461,21 @@ async function generate(params, mainWindow) {
     }
 
     return new Promise((resolve, reject) => {
-        send({ step: 0, totalSteps: params.steps || model.defaultSteps || 20, status: 'starting' });
+        send({ step: 0, totalSteps: steps, status: 'starting', progress: 0 });
 
         console.log('[sd-cli] command:', BINARY_PATH, args.join(' '));
         // DYLD_LIBRARY_PATH lets macOS find libstable-diffusion.dylib next to sd-cli
         const spawnEnv = { ...process.env, DYLD_LIBRARY_PATH: BIN_DIR, LD_LIBRARY_PATH: BIN_DIR };
         activeProcess = spawn(BINARY_PATH, args, { env: spawnEnv });
-        const stepRegex = /step\s+(\d+)\/(\d+)/i;
+        const progressState = { tail: '', lastStep: 0, lastTotalSteps: 0 };
         const outputLines = [];
 
         const handleOutput = (data) => {
             const line = data.toString();
             outputLines.push(line.trimEnd());
-            const match = line.match(stepRegex);
-            if (match) {
-                const step = parseInt(match[1]);
-                const total = parseInt(match[2]);
-                send({ step, totalSteps: total, status: 'generating', progress: step / total });
+            const progressEvents = parseGenerationProgressChunk(line, progressState);
+            for (const event of progressEvents) {
+                send({ ...event, status: 'generating' });
             }
         };
 
@@ -496,7 +499,7 @@ async function generate(params, mainWindow) {
                 const imgBuffer = fs.readFileSync(outPath);
                 const dataUrl = `data:image/png;base64,${imgBuffer.toString('base64')}`;
                 fs.unlinkSync(outPath);
-                send({ step: 1, totalSteps: 1, status: 'done', progress: 1 });
+                send({ step: steps, totalSteps: steps, status: 'done', progress: 1 });
                 resolve({ url: dataUrl, seed });
             } catch (err) {
                 reject(err);
@@ -534,4 +537,6 @@ function register() {
     ipcMain.handle('local-ai:cancel-generation', () => cancelGeneration());
 }
 
-module.exports = { register };
+module.exports = {
+    register,
+};

--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -4,7 +4,10 @@ const fs = require('fs');
 const https = require('https');
 const http = require('http');
 const { spawn, execFile } = require('child_process');
-const os = require('os');
+const {
+    getBundledBinaryResourceDir,
+    pickBinaryAssetForPlatform,
+} = require('./localInferenceAssets');
 
 // ─── Paths ────────────────────────────────────────────────────────────────────
 const DATA_DIR = path.join(app.getPath('userData'), 'local-ai');
@@ -27,40 +30,6 @@ const activeDownloads = new Map(); // modelId → request object
 // Asset names look like: sd-master-44cca3d-bin-Darwin-macOS-15.7.4-arm64.zip
 // We pick the best match in priority order so a single release that only
 // ships e.g. avx512 still resolves cleanly.
-function pickBinaryAsset(zipNames) {
-    const { platform, arch } = process;
-
-    // The "cudart" zip in recent leejet releases is just the CUDA runtime DLLs,
-    // not an sd-cli build, so it must never satisfy the Windows match.
-    const isSdCliZip = (n) => n.startsWith('sd-master-') || n.includes('-bin-');
-    const candidates = zipNames.filter(isSdCliZip);
-
-    if (platform === 'darwin') {
-        // leejet only publishes arm64 macOS builds. Mac Intel must use the
-        // hosted API instead — caller maps the empty result to a clear error.
-        if (arch !== 'arm64') return null;
-        return candidates.find(n => n.includes('Darwin') && n.includes('arm64')) || null;
-    }
-    if (platform === 'win32') {
-        // Priority: avx2 > avx > avx512 > noavx > cuda12. cuda needs the
-        // separate cudart runtime so we only fall back to it if nothing else.
-        const winCandidates = candidates.filter(n => /win-(avx2?|avx512|noavx|cuda12|cu12)-x64/.test(n));
-        const order = ['win-avx2-x64', 'win-avx-x64', 'win-avx512-x64', 'win-noavx-x64', 'win-cuda12-x64', 'win-cu12-x64'];
-        for (const tag of order) {
-            const hit = winCandidates.find(n => n.includes(tag));
-            if (hit) return hit;
-        }
-        return null;
-    }
-    // Linux: prefer plain x86_64, then vulkan, then rocm.
-    const linuxCandidates = candidates.filter(n => n.includes('Linux') && n.includes('x86_64'));
-    const plain = linuxCandidates.find(n => !n.includes('rocm') && !n.includes('vulkan'));
-    return plain
-        || linuxCandidates.find(n => n.includes('vulkan'))
-        || linuxCandidates.find(n => n.includes('rocm'))
-        || null;
-}
-
 function fetchJson(url) {
     return new Promise((resolve, reject) => {
         https.get(url, { headers: { 'User-Agent': 'open-generative-ai' } }, (res) => {
@@ -190,8 +159,43 @@ function findFile(dir, name) {
     return null;
 }
 
+function ensureBinaryPermissions() {
+    if (process.platform === 'win32') return;
+
+    for (const fileName of [
+        BINARY_NAME,
+        'sd-server',
+        'libstable-diffusion.dylib',
+        'libstable-diffusion.so',
+    ]) {
+        const fullPath = findFile(BIN_DIR, fileName);
+        if (fullPath) fs.chmodSync(fullPath, 0o755);
+    }
+}
+
+function ensureBundledBinaryInstalled() {
+    if (fs.existsSync(BINARY_PATH)) {
+        ensureBinaryPermissions();
+        return true;
+    }
+
+    if (!app.isPackaged) return false;
+
+    const bundledDir = getBundledBinaryResourceDir({
+        resourcesPath: process.resourcesPath,
+        platform: process.platform,
+        arch: process.arch,
+    });
+    const bundledBinaryPath = path.join(bundledDir, BINARY_NAME);
+    if (!fs.existsSync(bundledBinaryPath)) return false;
+
+    fs.cpSync(bundledDir, BIN_DIR, { recursive: true, force: true });
+    ensureBinaryPermissions();
+    return fs.existsSync(BINARY_PATH);
+}
+
 async function getBinaryStatus() {
-    const exists = fs.existsSync(BINARY_PATH);
+    const exists = ensureBundledBinaryInstalled() || fs.existsSync(BINARY_PATH);
     return { exists, path: BINARY_PATH };
 }
 
@@ -206,6 +210,11 @@ async function downloadBinary(mainWindow) {
 
     try {
         send({ phase: 'fetching-release', progress: 0 });
+
+        if (ensureBundledBinaryInstalled()) {
+            send({ phase: 'done', progress: 1 });
+            return { ok: true, source: 'bundled' };
+        }
 
         const platformKey = `${process.platform}-${process.arch}`;
         const customUrl = CUSTOM_BINARIES[platformKey];
@@ -230,7 +239,11 @@ async function downloadBinary(mainWindow) {
                 const zips = (release.assets || [])
                     .filter(a => a.name.endsWith('.zip'));
                 lastSeen = zips.map(a => a.name);
-                const pickedName = pickBinaryAsset(lastSeen);
+                const pickedName = pickBinaryAssetForPlatform({
+                    platform: process.platform,
+                    arch: process.arch,
+                    zipNames: lastSeen,
+                });
                 if (pickedName) {
                     chosen = zips.find(a => a.name === pickedName);
                     break;
@@ -240,6 +253,9 @@ async function downloadBinary(mainWindow) {
             if (!chosen) {
                 if (process.platform === 'darwin' && process.arch !== 'arm64') {
                     throw new Error('Local inference on macOS only supports Apple Silicon (M1/M2/M3/M4). Mac Intel is not supported by stable-diffusion.cpp upstream.');
+                }
+                if (process.platform === 'linux' && process.arch === 'arm64') {
+                    throw new Error('No upstream stable-diffusion.cpp binary found for linux-arm64. Install a build that bundles local-ai/linux-arm64/bin or provide the binary manually.');
                 }
                 const available = lastSeen.join(', ') || '(none)';
                 throw new Error(`No binary found for ${process.platform}-${process.arch} in the last 15 releases. Latest release assets: ${available}`);
@@ -267,13 +283,7 @@ async function downloadBinary(mainWindow) {
             fs.renameSync(foundBinary, BINARY_PATH);
         }
 
-        // Make binary executable on Unix
-        if (process.platform !== 'win32') {
-            fs.chmodSync(BINARY_PATH, 0o755);
-            // Also chmod the dylib so it can be loaded
-            const dylib = findFile(BIN_DIR, 'libstable-diffusion.dylib');
-            if (dylib) fs.chmodSync(dylib, 0o755);
-        }
+        ensureBinaryPermissions();
 
         // macOS: strip Gatekeeper quarantine so the downloaded binary can run
         if (process.platform === 'darwin') {
@@ -384,6 +394,7 @@ async function generate(params, mainWindow) {
     const { LOCAL_MODEL_CATALOG, ZIMAGE_AUXILIARY } = require('./modelCatalog');
     const send = (data) => mainWindow?.webContents.send('local-ai:progress', data);
 
+    ensureBundledBinaryInstalled();
     if (!fs.existsSync(BINARY_PATH)) throw new Error('sd.cpp binary not installed. Download it in Settings > Local Models.');
 
     const model = LOCAL_MODEL_CATALOG.find(m => m.id === params.model);

--- a/electron/lib/localInferenceAssets.js
+++ b/electron/lib/localInferenceAssets.js
@@ -1,0 +1,49 @@
+const path = require('path');
+
+function pickBinaryAssetForPlatform({ platform, arch, zipNames }) {
+    const isSdCliZip = (name) => name.startsWith('sd-master-') || name.includes('-bin-');
+    const candidates = zipNames.filter(isSdCliZip);
+
+    if (platform === 'darwin') {
+        if (arch !== 'arm64') return null;
+        return candidates.find((name) => name.includes('Darwin') && name.includes('arm64')) || null;
+    }
+
+    if (platform === 'win32') {
+        const winCandidates = candidates.filter((name) => /win-(avx2?|avx512|noavx|cuda12|cu12)-x64/.test(name));
+        const order = ['win-avx2-x64', 'win-avx-x64', 'win-avx512-x64', 'win-noavx-x64', 'win-cuda12-x64', 'win-cu12-x64'];
+        for (const tag of order) {
+            const hit = winCandidates.find((name) => name.includes(tag));
+            if (hit) return hit;
+        }
+        return null;
+    }
+
+    if (platform === 'linux' && arch === 'arm64') {
+        const linuxArmCandidates = candidates.filter((name) =>
+            name.includes('Linux') && (name.includes('aarch64') || name.includes('arm64'))
+        );
+        const plain = linuxArmCandidates.find((name) => !name.includes('rocm') && !name.includes('vulkan'));
+        return plain
+            || linuxArmCandidates.find((name) => name.includes('vulkan'))
+            || linuxArmCandidates.find((name) => name.includes('rocm'))
+            || null;
+    }
+
+    const linuxCandidates = candidates.filter((name) => name.includes('Linux') && name.includes('x86_64'));
+    const plain = linuxCandidates.find((name) => !name.includes('rocm') && !name.includes('vulkan'));
+    return plain
+        || linuxCandidates.find((name) => name.includes('vulkan'))
+        || linuxCandidates.find((name) => name.includes('rocm'))
+        || null;
+}
+
+function getBundledBinaryResourceDir({ resourcesPath, platform, arch }) {
+    const pathLib = platform === 'win32' ? path.win32 : path.posix;
+    return pathLib.join(resourcesPath, 'local-ai', `${platform}-${arch}`, 'bin');
+}
+
+module.exports = {
+    getBundledBinaryResourceDir,
+    pickBinaryAssetForPlatform,
+};

--- a/electron/lib/localInferenceRuntime.js
+++ b/electron/lib/localInferenceRuntime.js
@@ -1,0 +1,93 @@
+function coerceFiniteNumber(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveGenerationSteps(params, model) {
+    const requested = coerceFiniteNumber(params?.steps);
+    if (requested !== null && requested > 0) {
+        return Math.max(1, Math.round(requested));
+    }
+
+    const modelDefault = coerceFiniteNumber(model?.defaultSteps);
+    if (modelDefault !== null && modelDefault > 0) {
+        return Math.max(1, Math.round(modelDefault));
+    }
+
+    return 20;
+}
+
+function resolveGuidanceScale(params, model) {
+    const requested = coerceFiniteNumber(params?.guidance_scale);
+    if (requested !== null) return requested;
+
+    const modelDefault = coerceFiniteNumber(model?.defaultGuidance);
+    if (modelDefault !== null) return modelDefault;
+
+    return 7.5;
+}
+
+function stripAnsiSequences(text) {
+    return text.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '');
+}
+
+function extractProgressEvents(text) {
+    const events = [];
+    const patterns = [
+        /step\s+(\d+)\s*\/\s*(\d+)/ig,
+        /(\d+)\s*\/\s*(\d+)\s*-\s*[\d.]+s\/it/ig,
+    ];
+
+    for (const pattern of patterns) {
+        let match = pattern.exec(text);
+        while (match) {
+            const step = Number.parseInt(match[1], 10);
+            const totalSteps = Number.parseInt(match[2], 10);
+            if (Number.isFinite(step) && Number.isFinite(totalSteps) && totalSteps > 0) {
+                events.push({
+                    step,
+                    totalSteps,
+                    progress: Math.min(1, step / totalSteps),
+                });
+            }
+            match = pattern.exec(text);
+        }
+    }
+
+    events.sort((left, right) => {
+        if (left.totalSteps !== right.totalSteps) return left.totalSteps - right.totalSteps;
+        return left.step - right.step;
+    });
+    return events;
+}
+
+function parseGenerationProgressChunk(chunk, state = { tail: '', lastStep: 0, lastTotalSteps: 0 }) {
+    const normalizedChunk = stripAnsiSequences(String(chunk)).replace(/\r/g, '\n');
+    const combined = `${state.tail}${normalizedChunk}`;
+    const events = extractProgressEvents(combined);
+    const freshEvents = [];
+
+    for (const event of events) {
+        if (event.totalSteps !== state.lastTotalSteps) {
+            state.lastTotalSteps = event.totalSteps;
+            state.lastStep = 0;
+        }
+        if (event.step > state.lastStep) {
+            state.lastStep = event.step;
+            freshEvents.push(event);
+        }
+    }
+
+    state.tail = combined.slice(-1024);
+    return freshEvents;
+}
+
+module.exports = {
+    coerceFiniteNumber,
+    extractProgressEvents,
+    parseGenerationProgressChunk,
+    resolveGenerationSteps,
+    resolveGuidanceScale,
+    stripAnsiSequences,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "workspaces": [
         "packages/studio",
         "packages/Vibe-Workflow/packages/workflow-builder",
-        "packages/Open-Poe-AI/packages/agents"
+        "packages/Open-Poe-AI/packages/agents",
+        "packages/Open-AI-Design-Agent/packages/design-agent"
       ],
       "dependencies": {
         "ai-agent": "file:./packages/Open-Poe-AI/packages/agents",
@@ -119,6 +120,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4997,6 +4999,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -5584,6 +5587,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5648,6 +5652,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5874,7 +5879,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -5894,7 +5898,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -5916,8 +5919,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -5925,7 +5927,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5941,8 +5942,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5950,7 +5950,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -6498,6 +6497,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7162,7 +7162,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -7301,7 +7300,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -7315,7 +7313,6 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -7356,7 +7353,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -7415,6 +7413,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7740,6 +7739,7 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -7947,7 +7947,6 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -7961,7 +7960,6 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -7977,7 +7975,6 @@
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -7991,7 +7988,6 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -8403,6 +8399,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8576,6 +8573,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9156,8 +9154,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -10740,7 +10737,8 @@
           "url": "https://github.com/sponsors/lavrton"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -10775,7 +10773,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -10788,8 +10785,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -10797,7 +10793,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10813,8 +10808,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -10822,7 +10816,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11157,32 +11150,28 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -11196,8 +11185,7 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -12577,6 +12565,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
       "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
@@ -12629,6 +12618,7 @@
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
       "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
@@ -13339,6 +13329,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13528,8 +13519,7 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -13653,6 +13643,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13662,6 +13653,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13880,7 +13872,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -13891,7 +13882,6 @@
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -13902,7 +13892,6 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -15389,7 +15378,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -15524,6 +15512,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15757,6 +15746,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16107,6 +16097,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -16439,7 +16430,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -16455,7 +16445,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
     "electron:build": "vite build && electron-builder --mac",
     "electron:build:win": "vite build && electron-builder --win",
     "electron:build:linux": "vite build && electron-builder --linux",
+    "electron:build:linux:dir": "vite build && electron-builder --linux dir",
+    "electron:build:linux:arm64:dir": "vite build && electron-builder --linux dir --arm64",
+    "stage:local-ai": "node scripts/stage-local-ai-binary.js",
+    "package:linux:deb": "node scripts/package-linux-deb.js",
+    "package:linux:deb:arm64": "node scripts/package-linux-deb.js --arch arm64",
+    "package:linux:deb:x64": "node scripts/package-linux-deb.js --arch x64",
     "electron:build:all": "vite build && electron-builder --mac --win --linux"
   },
   "build": {
@@ -39,6 +45,15 @@
     "files": [
       "dist/**/*",
       "electron/**/*"
+    ],
+    "extraResources": [
+      {
+        "from": "build/local-ai",
+        "to": "local-ai",
+        "filter": [
+          "**/*"
+        ]
+      }
     ],
     "mac": {
       "category": "public.app-category.graphics-design",
@@ -56,6 +71,7 @@
     },
     "win": {
       "icon": "public/banner.png",
+      "signAndEditExecutable": false,
       "target": [
         {
           "target": "nsis",

--- a/scripts/package-linux-deb.js
+++ b/scripts/package-linux-deb.js
@@ -1,0 +1,192 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PACKAGE_JSON = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+const PRODUCT_NAME = PACKAGE_JSON.build?.productName || 'Open Generative AI';
+const PACKAGE_NAME = 'open-generative-ai';
+const COMMAND_NAME = 'open-generative-ai';
+const INSTALL_DIR_NAME = PACKAGE_NAME;
+const LINUX_DEPENDS = [
+    'libasound2t64 | libasound2',
+    'libatk-bridge2.0-0',
+    'libatk1.0-0',
+    'libc6',
+    'libcairo2',
+    'libcups2t64 | libcups2',
+    'libdrm2',
+    'libgbm1',
+    'libglib2.0-0',
+    'libgtk-3-0',
+    'libnspr4',
+    'libnss3',
+    'libpango-1.0-0',
+    'libx11-6',
+    'libx11-xcb1',
+    'libxcb-dri3-0',
+    'libxcomposite1',
+    'libxdamage1',
+    'libxext6',
+    'libxfixes3',
+    'libxkbcommon0',
+    'libxrandr2',
+    'xdg-utils',
+].join(', ');
+
+function parseArgs(argv) {
+    const args = {};
+
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (!arg.startsWith('--')) continue;
+
+        const [rawKey, inlineValue] = arg.slice(2).split('=');
+        if (inlineValue !== undefined) {
+            args[rawKey] = inlineValue;
+            continue;
+        }
+
+        const nextValue = argv[i + 1];
+        if (nextValue && !nextValue.startsWith('--')) {
+            args[rawKey] = nextValue;
+            i += 1;
+        } else {
+            args[rawKey] = true;
+        }
+    }
+
+    return args;
+}
+
+function toDebArch(arch) {
+    if (arch === 'x64') return 'amd64';
+    if (arch === 'arm64') return 'arm64';
+    return arch;
+}
+
+function getDefaultAppDir(arch) {
+    const folderName = arch === 'arm64' ? 'linux-arm64-unpacked' : 'linux-unpacked';
+    return path.join(REPO_ROOT, 'release', folderName);
+}
+
+function detectExecutableName(appDir) {
+    const preferredNames = [PRODUCT_NAME, PACKAGE_JSON.productName, PACKAGE_JSON.name]
+        .filter(Boolean);
+
+    for (const fileName of preferredNames) {
+        const fullPath = path.join(appDir, fileName);
+        if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+            return fileName;
+        }
+    }
+
+    const denyList = new Set([
+        'chrome-sandbox',
+        'chrome_crashpad_handler',
+    ]);
+
+    const candidates = fs.readdirSync(appDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => entry.name)
+        .filter((name) => !denyList.has(name))
+        .filter((name) => !name.endsWith('.so') && !name.includes('.so.'))
+        .filter((name) => (fs.statSync(path.join(appDir, name)).mode & 0o111) !== 0);
+
+    if (candidates.length === 0) {
+        throw new Error(`Could not detect the packaged executable in ${appDir}`);
+    }
+
+    return candidates[0];
+}
+
+function writeFile(targetPath, contents, mode) {
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, contents);
+    if (mode) fs.chmodSync(targetPath, mode);
+}
+
+function main() {
+    if (process.platform !== 'linux') {
+        console.error('This packaging script must be run on Linux.');
+        process.exit(1);
+    }
+
+    const args = parseArgs(process.argv.slice(2));
+    const arch = args.arch || process.arch;
+    const debArch = toDebArch(arch);
+    const appDir = path.resolve(args['app-dir'] || getDefaultAppDir(arch));
+    const outputDir = path.resolve(args['output-dir'] || path.join(REPO_ROOT, 'release'));
+    const version = args.version || PACKAGE_JSON.version;
+
+    if (!fs.existsSync(appDir)) {
+        console.error(`Packaged app directory not found: ${appDir}`);
+        process.exit(1);
+    }
+
+    const executableName = detectExecutableName(appDir);
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'oga-deb-'));
+    const packageRoot = path.join(tempRoot, 'pkgroot');
+    const installDir = path.join(packageRoot, 'opt', INSTALL_DIR_NAME);
+    const wrapperPath = path.join(packageRoot, 'usr', 'bin', COMMAND_NAME);
+    const desktopPath = path.join(packageRoot, 'usr', 'share', 'applications', `${PACKAGE_NAME}.desktop`);
+    const iconPath = path.join(packageRoot, 'usr', 'share', 'pixmaps', `${PACKAGE_NAME}.png`);
+    const controlPath = path.join(packageRoot, 'DEBIAN', 'control');
+    const outputPath = path.join(outputDir, `${PACKAGE_NAME}_${version}_${debArch}.deb`);
+
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.cpSync(appDir, installDir, { recursive: true });
+
+    const chromeSandboxPath = path.join(installDir, 'chrome-sandbox');
+    if (fs.existsSync(chromeSandboxPath)) {
+        fs.chmodSync(chromeSandboxPath, 0o4755);
+    }
+
+    writeFile(
+        wrapperPath,
+        `#!/bin/sh\nexec "/opt/${INSTALL_DIR_NAME}/${executableName}" "$@"\n`,
+        0o755
+    );
+
+    writeFile(
+        desktopPath,
+        `[Desktop Entry]
+Name=${PRODUCT_NAME}
+Exec=${COMMAND_NAME}
+Icon=${PACKAGE_NAME}
+Type=Application
+Categories=Graphics;Utility;
+Terminal=false
+StartupNotify=true
+`,
+        0o644
+    );
+
+    fs.mkdirSync(path.dirname(iconPath), { recursive: true });
+    fs.copyFileSync(path.join(REPO_ROOT, 'public', 'banner.png'), iconPath);
+    fs.chmodSync(iconPath, 0o644);
+
+    writeFile(
+        controlPath,
+        `Package: ${PACKAGE_NAME}
+Version: ${version}
+Section: graphics
+Priority: optional
+Architecture: ${debArch}
+Maintainer: Open Generative AI Team
+Depends: ${LINUX_DEPENDS}
+Description: Local-first generative AI studio for image, video, and design workflows
+`,
+        0o644
+    );
+
+    execFileSync('dpkg-deb', ['--build', '--root-owner-group', packageRoot, outputPath], {
+        stdio: 'inherit',
+    });
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    console.log(`Created ${outputPath}`);
+}
+
+main();

--- a/scripts/stage-local-ai-binary.js
+++ b/scripts/stage-local-ai-binary.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+
+const REQUIRED_FILES = {
+    darwin: ['sd-cli', 'libstable-diffusion.dylib'],
+    linux: ['sd-cli', 'libstable-diffusion.so'],
+    win32: ['sd-cli.exe'],
+};
+
+const OPTIONAL_FILES = ['sd-server'];
+
+function resolveSourceBinDir(sourcePath) {
+    const absoluteSourcePath = path.resolve(sourcePath);
+    const nestedBinDir = path.join(absoluteSourcePath, 'bin');
+
+    if (fs.existsSync(nestedBinDir) && fs.statSync(nestedBinDir).isDirectory()) {
+        return nestedBinDir;
+    }
+
+    return absoluteSourcePath;
+}
+
+function stageLocalAiBinary({ platform, arch, sourcePath }) {
+    const sourceBinDir = resolveSourceBinDir(sourcePath);
+    const requiredFiles = REQUIRED_FILES[platform];
+
+    if (!requiredFiles) {
+        throw new Error(`Unsupported platform "${platform}". Expected one of: ${Object.keys(REQUIRED_FILES).join(', ')}`);
+    }
+
+    const missingFiles = requiredFiles.filter((fileName) => !fs.existsSync(path.join(sourceBinDir, fileName)));
+    if (missingFiles.length > 0) {
+        throw new Error(`Missing required files in ${sourceBinDir}: ${missingFiles.join(', ')}`);
+    }
+
+    const repoRoot = path.resolve(__dirname, '..');
+    const stageDir = path.join(repoRoot, 'build', 'local-ai', `${platform}-${arch}`, 'bin');
+
+    fs.rmSync(stageDir, { recursive: true, force: true });
+    fs.mkdirSync(stageDir, { recursive: true });
+
+    for (const fileName of [...requiredFiles, ...OPTIONAL_FILES]) {
+        const sourceFile = path.join(sourceBinDir, fileName);
+        if (!fs.existsSync(sourceFile)) continue;
+
+        const targetFile = path.join(stageDir, fileName);
+        fs.copyFileSync(sourceFile, targetFile);
+
+        if (platform !== 'win32') {
+            fs.chmodSync(targetFile, 0o755);
+        }
+    }
+
+    return stageDir;
+}
+
+function main() {
+    const [platform, arch, sourcePath] = process.argv.slice(2);
+
+    if (!platform || !arch || !sourcePath) {
+        console.error('Usage: node scripts/stage-local-ai-binary.js <platform> <arch> <source-path>');
+        process.exit(1);
+    }
+
+    try {
+        const stageDir = stageLocalAiBinary({ platform, arch, sourcePath });
+        console.log(`Staged local AI binaries in ${stageDir}`);
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    resolveSourceBinDir,
+    stageLocalAiBinary,
+};

--- a/tests/localInferenceAssets.test.js
+++ b/tests/localInferenceAssets.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    pickBinaryAssetForPlatform,
+    getBundledBinaryResourceDir,
+} = require('../electron/lib/localInferenceAssets');
+
+test('pickBinaryAssetForPlatform prefers native linux arm64 assets', () => {
+    const zipNames = [
+        'sd-master-abc-bin-Linux-Ubuntu-24.04-x86_64.zip',
+        'sd-master-abc-bin-Linux-Ubuntu-24.04-aarch64.zip',
+        'sd-master-abc-bin-Linux-Ubuntu-24.04-aarch64-vulkan.zip',
+    ];
+
+    const picked = pickBinaryAssetForPlatform({
+        platform: 'linux',
+        arch: 'arm64',
+        zipNames,
+    });
+
+    assert.equal(picked, 'sd-master-abc-bin-Linux-Ubuntu-24.04-aarch64.zip');
+});
+
+test('getBundledBinaryResourceDir resolves linux arm64 bundled path', () => {
+    const bundledDir = getBundledBinaryResourceDir({
+        resourcesPath: '/opt/Open Generative AI/resources',
+        platform: 'linux',
+        arch: 'arm64',
+    });
+
+    assert.equal(
+        bundledDir,
+        '/opt/Open Generative AI/resources/local-ai/linux-arm64/bin'
+    );
+});

--- a/tests/localInferenceProgress.test.js
+++ b/tests/localInferenceProgress.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    parseGenerationProgressChunk,
+    resolveGenerationSteps,
+    resolveGuidanceScale,
+    stripAnsiSequences,
+} = require('../electron/lib/localInferenceRuntime');
+
+test('resolveGenerationSteps prefers explicit request over model defaults', () => {
+    const steps = resolveGenerationSteps({ steps: 3 }, { defaultSteps: 20 });
+    assert.equal(steps, 3);
+});
+
+test('resolveGuidanceScale prefers explicit request over model defaults', () => {
+    const guidance = resolveGuidanceScale({ guidance_scale: 5.25 }, { defaultGuidance: 7.5 });
+    assert.equal(guidance, 5.25);
+});
+
+test('stripAnsiSequences removes terminal control codes', () => {
+    const cleaned = stripAnsiSequences('\u001b[32mhello\u001b[0m');
+    assert.equal(cleaned, 'hello');
+});
+
+test('parseGenerationProgressChunk extracts sd-cli sampling progress from carriage-return output', () => {
+    const state = { tail: '', lastStep: 0, lastTotalSteps: 0 };
+    const chunk = '\r  |==>                                               | 1/20 - 7.16s/it\u001b[K\r  |=====>                                            | 2/20 - 6.98s/it\u001b[K';
+    const events = parseGenerationProgressChunk(chunk, state);
+
+    assert.deepEqual(events, [
+        { step: 1, totalSteps: 20, progress: 0.05 },
+        { step: 2, totalSteps: 20, progress: 0.1 },
+    ]);
+});
+
+test('parseGenerationProgressChunk de-duplicates repeated progress events across chunks', () => {
+    const state = { tail: '', lastStep: 0, lastTotalSteps: 0 };
+    const first = parseGenerationProgressChunk('\r  |==> | 1/20 - 7.16s/it\u001b[K', state);
+    const second = parseGenerationProgressChunk('\r  |==> | 1/20 - 7.16s/it\u001b[K\r  |=====> | 2/20 - 6.98s/it\u001b[K', state);
+
+    assert.deepEqual(first, [{ step: 1, totalSteps: 20, progress: 0.05 }]);
+    assert.deepEqual(second, [{ step: 2, totalSteps: 20, progress: 0.1 }]);
+});
+
+test('parseGenerationProgressChunk does not replay old buffered steps when later chunks include earlier output', () => {
+    const state = { tail: '', lastStep: 0, lastTotalSteps: 0 };
+    const first = parseGenerationProgressChunk('\r  |==> | 1/3 - 1.00s/it\u001b[K\r  |=====> | 2/3 - 1.00s/it\u001b[K', state);
+    const second = parseGenerationProgressChunk('\r  |==> | 1/3 - 1.00s/it\u001b[K\r  |=====> | 2/3 - 1.00s/it\u001b[K\r  |========> | 3/3 - 1.00s/it\u001b[K', state);
+
+    assert.deepEqual(first, [
+        { step: 1, totalSteps: 3, progress: 1 / 3 },
+        { step: 2, totalSteps: 3, progress: 2 / 3 },
+    ]);
+    assert.deepEqual(second, [
+        { step: 3, totalSteps: 3, progress: 1 },
+    ]);
+});


### PR DESCRIPTION
## What changed
- added bundled local inference asset resolution for packaged builds
- taught the Electron app to reuse bundled `sd.cpp` binaries before falling back to upstream downloads
- added staging and custom Debian packaging scripts for Linux x64 and ARM64 builds
- fixed Linux packaging details such as `chrome-sandbox` permissions and a space-free install path
- moved the `Open-AI-Design-Agent` submodule pointer to a healthy commit and added a focused asset-selection test

## Why it changed
The upstream project handled local inference downloads well for macOS and x64 Linux, but it did not provide a workable packaged path for ARM64 Linux. That blocked HP Spark, and the stock bootstrap path could also fail because the pinned design-agent submodule commit contains a broken nested gitlink.

## Impact
- packaged Linux builds can now ship a ready-to-run local `sd.cpp` runtime under `resources/local-ai/...`
- HP Spark ARM64 and Ubuntu x86_64 systems can run local Image Studio with bundled inference binaries
- Windows packaging remains buildable locally with the updated packaging settings
- Linux `.deb` output is now produced by a repo-local script instead of relying on the ARM64-unfriendly electron-builder FPM path

## Root cause
- no packaged Linux ARM64 local inference path existed in the app runtime
- upstream `stable-diffusion.cpp` release matching was too narrow for our deployment needs
- the pinned `Open-AI-Design-Agent` submodule commit referenced a broken nested submodule layout
- Linux desktop packaging needed explicit handling for `chrome-sandbox` and the executable install path

## Validation
- `node --test tests/localInferenceAssets.test.js`
- `node --check electron/lib/localInference.js`
- `node --check scripts/package-linux-deb.js`
- built and installed Windows x64 package locally
- built ARM64 package and deployed on HP Spark Ubuntu ARM64
- built amd64 package and deployed on Ubuntu x86_64 with RTX 3060