### PR TITLE
feat(local-ai): support custom storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ Both engines share the same UI: open **Settings → Local Models** to configure 
 
 All downloads happen inside the app. Nothing is installed system-wide.
 
+By default, `sd.cpp` stores the engine, model weights, and temporary downloads under Electron's app data directory. Common paths are:
+
+- macOS: `~/Library/Application Support/open-generative-ai/local-ai`
+- Windows: `%APPDATA%\open-generative-ai\local-ai`
+- Linux: `~/.config/open-generative-ai/local-ai`
+
+To keep multi-GB model weights on another drive, set `OPEN_GENERATIVE_AI_LOCAL_AI_DIR`
+before launching the desktop app. The app will create `bin/`, `models/`, and `tmp/`
+inside that directory, and **Settings -> Local Models** shows the resolved model folder.
+Local engine output and download errors are written to the app process console, so launch
+from Terminal or PowerShell when you need troubleshooting logs.
+
 ### Engine 2 — Wan2GP (remote Gradio server)
 
 The app does **not** bundle Python or model weights for Wan2GP. You run Wan2GP yourself on a machine with a CUDA or ROCm GPU and point the desktop app at its URL.
@@ -198,7 +210,7 @@ If you want to confirm sd.cpp is installed correctly without going through the U
 
 ```bash
 # 1. App data layout (created on first app launch)
-APP_DATA="$HOME/Library/Application Support/open-generative-ai/local-ai"
+APP_DATA="${OPEN_GENERATIVE_AI_LOCAL_AI_DIR:-$HOME/Library/Application Support/open-generative-ai/local-ai}"
 ls "$APP_DATA/bin"     # sd-cli, libstable-diffusion.dylib
 ls "$APP_DATA/models"  # whatever you've downloaded
 

--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -13,12 +13,18 @@ const {
     resolveGenerationSteps,
     resolveGuidanceScale,
 } = require('./localInferenceRuntime');
+const {
+    LOCAL_AI_DIR_ENV,
+    resolveLocalAiPaths,
+} = require('./localInferencePaths');
 
 // ─── Paths ────────────────────────────────────────────────────────────────────
-const DATA_DIR = path.join(app.getPath('userData'), 'local-ai');
-const BIN_DIR = path.join(DATA_DIR, 'bin');
-const MODELS_DIR = path.join(DATA_DIR, 'models');
-const TMP_DIR = path.join(DATA_DIR, 'tmp');
+const {
+    dataDir: DATA_DIR,
+    binDir: BIN_DIR,
+    modelsDir: MODELS_DIR,
+    tmpDir: TMP_DIR,
+} = resolveLocalAiPaths({ userDataPath: app.getPath('userData') });
 
 for (const dir of [BIN_DIR, MODELS_DIR, TMP_DIR]) {
     fs.mkdirSync(dir, { recursive: true });
@@ -201,7 +207,13 @@ function ensureBundledBinaryInstalled() {
 
 async function getBinaryStatus() {
     const exists = ensureBundledBinaryInstalled() || fs.existsSync(BINARY_PATH);
-    return { exists, path: BINARY_PATH };
+    return {
+        exists,
+        path: BINARY_PATH,
+        dataDir: DATA_DIR,
+        modelsDir: MODELS_DIR,
+        envVar: LOCAL_AI_DIR_ENV,
+    };
 }
 
 // Metal-enabled binaries hosted on our own release (macOS arm64 only).

--- a/electron/lib/localInferencePaths.js
+++ b/electron/lib/localInferencePaths.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+const LOCAL_AI_DIR_ENV = 'OPEN_GENERATIVE_AI_LOCAL_AI_DIR';
+
+function normalizeDirOverride(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function resolveLocalAiPaths({ userDataPath, env = process.env } = {}) {
+    const customDir = normalizeDirOverride(env[LOCAL_AI_DIR_ENV]);
+
+    if (!customDir && !userDataPath) {
+        throw new Error(`userDataPath is required when ${LOCAL_AI_DIR_ENV} is not set`);
+    }
+
+    const dataDir = path.resolve(customDir || path.join(userDataPath, 'local-ai'));
+
+    return {
+        dataDir,
+        binDir: path.join(dataDir, 'bin'),
+        modelsDir: path.join(dataDir, 'models'),
+        tmpDir: path.join(dataDir, 'tmp'),
+    };
+}
+
+module.exports = {
+    LOCAL_AI_DIR_ENV,
+    resolveLocalAiPaths,
+};

--- a/src/components/LocalModelManager.js
+++ b/src/components/LocalModelManager.js
@@ -368,15 +368,29 @@ export function LocalModelManager() {
     const modelsSection = document.createElement('div');
     modelsSection.className = 'flex flex-col gap-3';
     modelsSection.innerHTML = `
-        <div class="flex items-center justify-between">
-            <h3 class="text-xs font-bold text-secondary uppercase tracking-wider">Local Models</h3>
-            <span class="text-[10px] text-muted">Stored in your app data folder</span>
+        <div class="flex items-center justify-between gap-3">
+            <h3 class="text-xs font-bold text-secondary uppercase tracking-wider shrink-0">Local Models</h3>
+            <span id="local-model-storage" class="min-w-0 truncate text-right text-[10px] text-muted">Checking storage...</span>
         </div>
         <div id="local-model-list" class="flex flex-col gap-3"></div>
     `;
     root.appendChild(modelsSection);
 
     const listEl = modelsSection.querySelector('#local-model-list');
+    const storageEl = modelsSection.querySelector('#local-model-storage');
+
+    const refreshStorageInfo = async () => {
+        try {
+            const status = await localAI.getBinaryStatus();
+            const storagePath = status.modelsDir || status.dataDir;
+            storageEl.textContent = storagePath ? `Stored in ${storagePath}` : 'Stored in your app data folder';
+            if (storagePath && status.envVar) {
+                storageEl.title = `Set ${status.envVar} before launch to change this location`;
+            }
+        } catch (_) {
+            storageEl.textContent = 'Stored in your app data folder';
+        }
+    };
 
     const renderModels = async () => {
         listEl.innerHTML = `<div class="text-xs text-muted text-center py-4">Loading...</div>`;
@@ -391,6 +405,7 @@ export function LocalModelManager() {
         }
     };
 
+    refreshStorageInfo();
     renderModels();
 
     return root;

--- a/tests/localInferencePaths.test.js
+++ b/tests/localInferencePaths.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+    LOCAL_AI_DIR_ENV,
+    resolveLocalAiPaths,
+} = require('../electron/lib/localInferencePaths');
+
+test('resolveLocalAiPaths defaults under the Electron user data directory', () => {
+    const userDataPath = path.join(process.cwd(), 'fixtures', 'user-data');
+    const paths = resolveLocalAiPaths({ userDataPath, env: {} });
+    const dataDir = path.resolve(userDataPath, 'local-ai');
+
+    assert.deepEqual(paths, {
+        dataDir,
+        binDir: path.join(dataDir, 'bin'),
+        modelsDir: path.join(dataDir, 'models'),
+        tmpDir: path.join(dataDir, 'tmp'),
+    });
+});
+
+test('resolveLocalAiPaths honors a custom local AI directory', () => {
+    const customDir = path.join(process.cwd(), 'fixtures', 'custom-ai-store');
+    const paths = resolveLocalAiPaths({
+        userDataPath: path.join(process.cwd(), 'fixtures', 'ignored-user-data'),
+        env: { [LOCAL_AI_DIR_ENV]: customDir },
+    });
+    const dataDir = path.resolve(customDir);
+
+    assert.equal(paths.dataDir, dataDir);
+    assert.equal(paths.modelsDir, path.join(dataDir, 'models'));
+});
+
+test('resolveLocalAiPaths trims accidental whitespace around the override', () => {
+    const customDir = path.join(process.cwd(), 'fixtures', 'spaced-ai-store');
+    const paths = resolveLocalAiPaths({
+        env: { [LOCAL_AI_DIR_ENV]: `  ${customDir}  ` },
+    });
+
+    assert.equal(paths.dataDir, path.resolve(customDir));
+});
+
+test('resolveLocalAiPaths requires userDataPath when no override is set', () => {
+    assert.throws(
+        () => resolveLocalAiPaths({ env: {} }),
+        /userDataPath is required/
+    );
+});


### PR DESCRIPTION
## Summary
- add `OPEN_GENERATIVE_AI_LOCAL_AI_DIR` support for sd.cpp engine/model/temp storage
- expose the resolved local AI data/model directories through the existing binary status IPC
- show the active model folder in Settings -> Local Models and document defaults, override usage, and console log capture

## Why
Issue #168 reports that users cannot tell where local model data lives or move multi-GB model weights off the default app data drive. The previous path was hard-coded under Electron `userData`, so machines with small OS disks had no supported escape hatch.

This PR addresses the storage-location portion of #168 while keeping the change small and testable.

## Test plan
- `node --test tests/localInferencePaths.test.js`
- `node --test tests/localInferenceAssets.test.js tests/localInferenceProgress.test.js tests/localInferencePaths.test.js`
- `node --check electron/lib/localInferencePaths.js`
- `node --check electron/lib/localInference.js`