### PR TITLE
[codex] Follow up local-ai staging for unpackaged Electron runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ dist-ssr
 # Electron build output
 release/
 .webpack/
+build/local-ai/*
+!build/local-ai/README.md
 
 # Next.js
 .next/

--- a/electron/lib/comfyUiCatalog.js
+++ b/electron/lib/comfyUiCatalog.js
@@ -1,0 +1,72 @@
+const fs = require('fs');
+const path = require('path');
+
+const COMFYUI_MODEL_HINTS = {
+    '__llm__': [
+        'models/text_encoders/Qwen3-4B-Instruct-2507-UD-Q4_K_XL.gguf',
+    ],
+    '__vae__': [
+        'models/vae/ae.safetensors',
+    ],
+    'anything-v5': [
+        'models/checkpoints/Anything-v5.0-PRT.safetensors',
+    ],
+    'dreamshaper-8': [
+        'models/checkpoints/DreamShaper_8_pruned.safetensors',
+    ],
+    'realistic-vision-v51': [
+        'models/checkpoints/Realistic_Vision_V5.1_fp16-no-ema.safetensors',
+        'models/checkpoints/realisticVisionV51_v51VAE.safetensors',
+    ],
+    'stable-diffusion-xl-base': [
+        'models/checkpoints/sd_xl_base_1.0.safetensors',
+    ],
+    'z-image-base': [
+        'models/checkpoints/Z-Image-Q4_K_M.gguf',
+        'models/diffusion_models/Z-Image-Q4_K_M.gguf',
+    ],
+    'z-image-turbo': [
+        'models/checkpoints/z_image_turbo-Q4_K.gguf',
+        'models/diffusion_models/z_image_turbo-Q4_K.gguf',
+    ],
+};
+
+function uniq(items) {
+    return [...new Set(items.filter(Boolean))];
+}
+
+function getComfyUiSearchPaths({ modelId, filename }) {
+    const hints = COMFYUI_MODEL_HINTS[modelId] || [];
+    const generic = filename ? [
+        `models/checkpoints/${filename}`,
+        `models/diffusion_models/${filename}`,
+        `models/text_encoders/${filename}`,
+        `models/vae/${filename}`,
+    ] : [];
+
+    return uniq([...hints, ...generic]);
+}
+
+function findComfyUiModelSource({
+    comfyUiPath,
+    modelId,
+    filename,
+    existsSync = fs.existsSync,
+} = {}) {
+    if (!comfyUiPath) return null;
+
+    for (const relativePath of getComfyUiSearchPaths({ modelId, filename })) {
+        const absolutePath = path.join(comfyUiPath, relativePath);
+        if (existsSync(absolutePath)) {
+            return absolutePath;
+        }
+    }
+
+    return null;
+}
+
+module.exports = {
+    COMFYUI_MODEL_HINTS,
+    findComfyUiModelSource,
+    getComfyUiSearchPaths,
+};

--- a/electron/lib/comfyUiConfig.js
+++ b/electron/lib/comfyUiConfig.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function getPathLib(platform) {
+    return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function normalizeComfyUiPath(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function getDefaultUserDataDir({
+    platform = process.platform,
+    homeDir = os.homedir(),
+    appDataDir = process.env.APPDATA || '',
+} = {}) {
+    const pathLib = getPathLib(platform);
+
+    if (platform === 'win32') {
+        return pathLib.join(appDataDir || pathLib.join(homeDir, 'AppData', 'Roaming'), 'Open Generative AI');
+    }
+    if (platform === 'darwin') {
+        return pathLib.join(homeDir, 'Library', 'Application Support', 'open-generative-ai');
+    }
+    return pathLib.join(homeDir, '.config', 'open-generative-ai');
+}
+
+function getDefaultComfyUiPath({
+    platform = process.platform,
+    homeDir = os.homedir(),
+} = {}) {
+    const pathLib = getPathLib(platform);
+
+    if (platform === 'win32') {
+        return pathLib.join(homeDir, 'ComfyUI');
+    }
+    return pathLib.join(homeDir, 'apps', 'ComfyUI');
+}
+
+function getComfyUiConfigFile({
+    dataDir,
+    platform = process.platform,
+} = {}) {
+    return getPathLib(platform).join(dataDir, 'comfyui.json');
+}
+
+function readComfyUiConfig({
+    configFile,
+    existsSync = fs.existsSync,
+    readFileSync = fs.readFileSync,
+} = {}) {
+    if (!configFile || !existsSync(configFile)) {
+        return { path: '' };
+    }
+
+    try {
+        const parsed = JSON.parse(readFileSync(configFile, 'utf-8'));
+        return { path: normalizeComfyUiPath(parsed.path) };
+    } catch {
+        return { path: '' };
+    }
+}
+
+function writeComfyUiConfig({
+    configFile,
+    config,
+    mkdirSync = fs.mkdirSync,
+    writeFileSync = fs.writeFileSync,
+} = {}) {
+    mkdirSync(path.dirname(configFile), { recursive: true });
+    writeFileSync(configFile, JSON.stringify({
+        path: normalizeComfyUiPath(config?.path),
+    }, null, 2));
+}
+
+function resolveComfyUiPath({
+    config = {},
+    env = process.env,
+    platform = process.platform,
+    homeDir = os.homedir(),
+} = {}) {
+    const envPath = normalizeComfyUiPath(env.OPEN_GENERATIVE_AI_COMFYUI_PATH);
+    if (envPath) return envPath;
+
+    const configuredPath = normalizeComfyUiPath(config.path);
+    if (configuredPath) return configuredPath;
+
+    return getDefaultComfyUiPath({ platform, homeDir });
+}
+
+module.exports = {
+    getComfyUiConfigFile,
+    getDefaultComfyUiPath,
+    getDefaultUserDataDir,
+    normalizeComfyUiPath,
+    readComfyUiConfig,
+    resolveComfyUiPath,
+    writeComfyUiConfig,
+};

--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -5,7 +5,7 @@ const https = require('https');
 const http = require('http');
 const { spawn, execFile } = require('child_process');
 const {
-    getBundledBinaryResourceDir,
+    getLocalBinaryResourceDir,
     pickBinaryAssetForPlatform,
 } = require('./localInferenceAssets');
 const {
@@ -184,10 +184,11 @@ function ensureBundledBinaryInstalled() {
         return true;
     }
 
-    if (!app.isPackaged) return false;
-
-    const bundledDir = getBundledBinaryResourceDir({
+    const bundledDir = getLocalBinaryResourceDir({
+        appPath: app.getAppPath(),
+        moduleDir: __dirname,
         resourcesPath: process.resourcesPath,
+        isPackaged: app.isPackaged,
         platform: process.platform,
         arch: process.arch,
     });

--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -5,6 +5,14 @@ const https = require('https');
 const http = require('http');
 const { spawn, execFile } = require('child_process');
 const {
+    findComfyUiModelSource,
+} = require('./comfyUiCatalog');
+const {
+    getComfyUiConfigFile,
+    readComfyUiConfig,
+    resolveComfyUiPath,
+} = require('./comfyUiConfig');
+const {
     getLocalBinaryResourceDir,
     pickBinaryAssetForPlatform,
 } = require('./localInferenceAssets');
@@ -19,6 +27,11 @@ const DATA_DIR = path.join(app.getPath('userData'), 'local-ai');
 const BIN_DIR = path.join(DATA_DIR, 'bin');
 const MODELS_DIR = path.join(DATA_DIR, 'models');
 const TMP_DIR = path.join(DATA_DIR, 'tmp');
+const COMFYUI_CONFIG_FILE = getComfyUiConfigFile({
+    dataDir: DATA_DIR,
+    platform: process.platform,
+});
+const COMFYUI_LINKS_FILE = path.join(DATA_DIR, 'comfyui-links.json');
 
 for (const dir of [BIN_DIR, MODELS_DIR, TMP_DIR]) {
     fs.mkdirSync(dir, { recursive: true });
@@ -205,6 +218,147 @@ async function getBinaryStatus() {
     return { exists, path: BINARY_PATH };
 }
 
+function hasFileSystemEntry(filePath) {
+    try {
+        fs.lstatSync(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function readComfyUiLinkRegistry() {
+    if (!fs.existsSync(COMFYUI_LINKS_FILE)) return {};
+
+    try {
+        return JSON.parse(fs.readFileSync(COMFYUI_LINKS_FILE, 'utf-8'));
+    } catch {
+        return {};
+    }
+}
+
+function writeComfyUiLinkRegistry(registry) {
+    fs.writeFileSync(COMFYUI_LINKS_FILE, JSON.stringify(registry, null, 2));
+}
+
+function updateComfyUiLinkRecord(fileName, linkInfo) {
+    const registry = readComfyUiLinkRegistry();
+
+    if (linkInfo) {
+        registry[fileName] = linkInfo;
+    } else {
+        delete registry[fileName];
+    }
+
+    writeComfyUiLinkRegistry(registry);
+}
+
+function getResolvedComfyUiPath() {
+    const config = readComfyUiConfig({ configFile: COMFYUI_CONFIG_FILE });
+    return resolveComfyUiPath({
+        config,
+        env: process.env,
+        platform: process.platform,
+    });
+}
+
+function isPathInside(parentPath, childPath) {
+    const resolvedParent = path.resolve(parentPath);
+    const resolvedChild = path.resolve(childPath);
+    const relativePath = path.relative(resolvedParent, resolvedChild);
+    return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+function resolveExistingComfyUiLink(fileName) {
+    const targetPath = path.join(MODELS_DIR, fileName);
+    if (!hasFileSystemEntry(targetPath)) {
+        updateComfyUiLinkRecord(fileName, null);
+        return null;
+    }
+
+    const registry = readComfyUiLinkRegistry();
+    const recorded = registry[fileName];
+    if (recorded?.sourcePath) {
+        return recorded;
+    }
+
+    try {
+        const stat = fs.lstatSync(targetPath);
+        if (!stat.isSymbolicLink()) return null;
+
+        const sourcePath = fs.realpathSync(targetPath);
+        const comfyUiPath = getResolvedComfyUiPath();
+        if (!comfyUiPath || !isPathInside(comfyUiPath, sourcePath)) return null;
+
+        const detected = {
+            provider: 'comfyui',
+            comfyUiPath,
+            linkType: 'symlink',
+            sourcePath,
+        };
+        updateComfyUiLinkRecord(fileName, detected);
+        return detected;
+    } catch {
+        return null;
+    }
+}
+
+function linkModelFromComfyUi({ modelId, filename }) {
+    const targetPath = path.join(MODELS_DIR, filename);
+    const existingLink = resolveExistingComfyUiLink(filename);
+    if (existingLink) return existingLink;
+
+    if (hasFileSystemEntry(targetPath)) return null;
+
+    const comfyUiPath = getResolvedComfyUiPath();
+    const sourcePath = findComfyUiModelSource({
+        comfyUiPath,
+        modelId,
+        filename,
+    });
+    if (!sourcePath) return null;
+
+    try {
+        fs.symlinkSync(sourcePath, targetPath, 'file');
+        const linkInfo = {
+            provider: 'comfyui',
+            comfyUiPath,
+            linkType: 'symlink',
+            sourcePath,
+        };
+        updateComfyUiLinkRecord(filename, linkInfo);
+        return linkInfo;
+    } catch {
+        try {
+            fs.linkSync(sourcePath, targetPath);
+            const linkInfo = {
+                provider: 'comfyui',
+                comfyUiPath,
+                linkType: 'hardlink',
+                sourcePath,
+            };
+            updateComfyUiLinkRecord(filename, linkInfo);
+            return linkInfo;
+        } catch {
+            return null;
+        }
+    }
+}
+
+function ensureModelFileAvailable(model) {
+    const filePath = path.join(MODELS_DIR, model.filename);
+    const linkedFrom = resolveExistingComfyUiLink(model.filename) || linkModelFromComfyUi({
+        modelId: model.id,
+        filename: model.filename,
+    });
+
+    return {
+        exists: fs.existsSync(filePath),
+        filePath,
+        linkedFrom,
+    };
+}
+
 // Metal-enabled binaries hosted on our own release (macOS arm64 only).
 // Other platforms fall back to the stock leejet release.
 const CUSTOM_BINARIES = {
@@ -306,16 +460,30 @@ async function downloadBinary(mainWindow) {
 
 // ─── Model management ─────────────────────────────────────────────────────────
 function getModelState(model) {
-    const filePath = path.join(MODELS_DIR, model.filename);
+    const availability = ensureModelFileAvailable(model);
+    const filePath = availability.filePath;
     const partPath = filePath + '.part';
-    if (fs.existsSync(filePath)) return 'downloaded';
-    if (fs.existsSync(partPath)) return 'partial';
-    return 'not-downloaded';
+    if (availability.exists) {
+        return {
+            linkedFrom: availability.linkedFrom,
+            state: 'downloaded',
+        };
+    }
+    if (fs.existsSync(partPath)) {
+        return {
+            linkedFrom: null,
+            state: 'partial',
+        };
+    }
+    return {
+        linkedFrom: null,
+        state: 'not-downloaded',
+    };
 }
 
 function getAuxState(aux) {
-    const filePath = path.join(MODELS_DIR, aux.filename);
-    return fs.existsSync(filePath) ? 'downloaded' : 'not-downloaded';
+    const availability = ensureModelFileAvailable(aux);
+    return availability.exists ? 'downloaded' : 'not-downloaded';
 }
 
 async function listModels() {
@@ -326,7 +494,7 @@ async function listModels() {
     };
     return LOCAL_MODEL_CATALOG.map(m => ({
         ...m,
-        state: getModelState(m),
+        ...getModelState(m),
         path: path.join(MODELS_DIR, m.filename),
         ...(m.requiresAuxiliary ? { auxiliaryStatus: auxStatus } : {}),
     }));
@@ -338,7 +506,14 @@ async function downloadModel(modelId, mainWindow) {
     if (!model) throw new Error(`Unknown model: ${modelId}`);
 
     const destPath = path.join(MODELS_DIR, model.filename);
-    if (fs.existsSync(destPath)) return { ok: true, path: destPath };
+    const availability = ensureModelFileAvailable(model);
+    if (availability.exists) {
+        return {
+            ok: true,
+            path: destPath,
+            ...(availability.linkedFrom ? { source: 'comfyui' } : {}),
+        };
+    }
 
     const send = (data) => mainWindow?.webContents.send('local-ai:download-progress', { id: modelId, ...data });
     send({ phase: 'downloading', progress: 0 });
@@ -357,7 +532,14 @@ async function downloadAuxiliary(auxKey, mainWindow) {
     if (!aux) throw new Error(`Unknown auxiliary file: ${auxKey}`);
 
     const destPath = path.join(MODELS_DIR, aux.filename);
-    if (fs.existsSync(destPath)) return { ok: true, path: destPath };
+    const availability = ensureModelFileAvailable(aux);
+    if (availability.exists) {
+        return {
+            ok: true,
+            path: destPath,
+            ...(availability.linkedFrom ? { source: 'comfyui' } : {}),
+        };
+    }
 
     const id = aux.id;
     const send = (data) => mainWindow?.webContents.send('local-ai:download-progress', { id, ...data });
@@ -372,14 +554,16 @@ async function downloadAuxiliary(auxKey, mainWindow) {
 }
 
 async function deleteModel(modelId) {
-    const { LOCAL_MODEL_CATALOG } = require('./modelCatalog');
-    const model = LOCAL_MODEL_CATALOG.find(m => m.id === modelId);
+    const { LOCAL_MODEL_CATALOG, ZIMAGE_AUXILIARY } = require('./modelCatalog');
+    const model = LOCAL_MODEL_CATALOG.find(m => m.id === modelId)
+        || Object.values(ZIMAGE_AUXILIARY).find(aux => aux.id === modelId);
     if (!model) throw new Error(`Unknown model: ${modelId}`);
 
     const filePath = path.join(MODELS_DIR, model.filename);
     if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
     const partPath = filePath + '.part';
     if (fs.existsSync(partPath)) fs.unlinkSync(partPath);
+    updateComfyUiLinkRecord(model.filename, null);
     return { ok: true };
 }
 
@@ -406,14 +590,17 @@ async function generate(params, mainWindow) {
     const model = LOCAL_MODEL_CATALOG.find(m => m.id === params.model);
     if (!model) throw new Error(`Unknown local model: ${params.model}`);
 
-    const modelPath = path.join(MODELS_DIR, model.filename);
-    if (!fs.existsSync(modelPath)) throw new Error(`Model file not found. Download "${model.name}" in Settings > Local Models.`);
+    const modelAvailability = ensureModelFileAvailable(model);
+    const modelPath = modelAvailability.filePath;
+    if (!modelAvailability.exists) throw new Error(`Model file not found. Download "${model.name}" in Settings > Local Models.`);
 
     if (model.requiresAuxiliary) {
-        const llmPath = path.join(MODELS_DIR, ZIMAGE_AUXILIARY.llm.filename);
-        const vaePath = path.join(MODELS_DIR, ZIMAGE_AUXILIARY.vae.filename);
-        if (!fs.existsSync(llmPath)) throw new Error('Text encoder (Qwen3-4B) not downloaded. Go to Settings > Local Models and download all required files for Z-Image.');
-        if (!fs.existsSync(vaePath)) throw new Error('VAE (ae.safetensors) not downloaded. Go to Settings > Local Models and download all required files for Z-Image.');
+        const llmAvailability = ensureModelFileAvailable(ZIMAGE_AUXILIARY.llm);
+        const vaeAvailability = ensureModelFileAvailable(ZIMAGE_AUXILIARY.vae);
+        const llmPath = llmAvailability.filePath;
+        const vaePath = vaeAvailability.filePath;
+        if (!llmAvailability.exists) throw new Error('Text encoder (Qwen3-4B) not downloaded. Go to Settings > Local Models and download all required files for Z-Image.');
+        if (!vaeAvailability.exists) throw new Error('VAE (ae.safetensors) not downloaded. Go to Settings > Local Models and download all required files for Z-Image.');
     }
 
     const [width, height] = arToDimensions(params.aspect_ratio || '1:1', model.type);

--- a/electron/lib/localInferenceAssets.js
+++ b/electron/lib/localInferenceAssets.js
@@ -43,7 +43,22 @@ function getBundledBinaryResourceDir({ resourcesPath, platform, arch }) {
     return pathLib.join(resourcesPath, 'local-ai', `${platform}-${arch}`, 'bin');
 }
 
+function getLocalBinaryResourceDir({ appPath, moduleDir, resourcesPath, isPackaged, platform, arch }) {
+    const pathLib = platform === 'win32' ? path.win32 : path.posix;
+
+    if (isPackaged) {
+        return getBundledBinaryResourceDir({ resourcesPath, platform, arch });
+    }
+
+    const sourceRoot = moduleDir
+        ? pathLib.resolve(moduleDir, '..', '..')
+        : appPath;
+
+    return pathLib.join(sourceRoot, 'build', 'local-ai', `${platform}-${arch}`, 'bin');
+}
+
 module.exports = {
     getBundledBinaryResourceDir,
+    getLocalBinaryResourceDir,
     pickBinaryAssetForPlatform,
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "electron:build:linux:dir": "vite build && electron-builder --linux dir",
     "electron:build:linux:arm64:dir": "vite build && electron-builder --linux dir --arm64",
     "stage:local-ai": "node scripts/stage-local-ai-binary.js",
+    "set:comfyui-path": "node scripts/set-comfyui-path.js",
     "package:linux:deb": "node scripts/package-linux-deb.js",
     "package:linux:deb:arm64": "node scripts/package-linux-deb.js --arch arm64",
     "package:linux:deb:x64": "node scripts/package-linux-deb.js --arch x64",

--- a/scripts/set-comfyui-path.js
+++ b/scripts/set-comfyui-path.js
@@ -1,0 +1,70 @@
+const path = require('path');
+
+const {
+    getComfyUiConfigFile,
+    getDefaultUserDataDir,
+    normalizeComfyUiPath,
+    readComfyUiConfig,
+    resolveComfyUiPath,
+    writeComfyUiConfig,
+} = require('../electron/lib/comfyUiConfig');
+
+function parseArgs(argv) {
+    const args = { comfyUiPath: '', dataDir: '', clear: false };
+    const rest = [...argv];
+
+    while (rest.length > 0) {
+        const current = rest.shift();
+        if (current === '--data-dir') {
+            args.dataDir = rest.shift() || '';
+            continue;
+        }
+        if (current === '--clear') {
+            args.clear = true;
+            continue;
+        }
+        if (!args.comfyUiPath) {
+            args.comfyUiPath = current;
+        }
+    }
+
+    return args;
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const dataDir = args.dataDir || path.join(
+        getDefaultUserDataDir({ platform: process.platform }),
+        'local-ai'
+    );
+    const configFile = getComfyUiConfigFile({
+        dataDir,
+        platform: process.platform,
+    });
+
+    if (args.clear) {
+        writeComfyUiConfig({ configFile, config: { path: '' } });
+    } else if (args.comfyUiPath) {
+        writeComfyUiConfig({
+            configFile,
+            config: { path: normalizeComfyUiPath(args.comfyUiPath) },
+        });
+    }
+
+    const storedConfig = readComfyUiConfig({ configFile });
+    const resolvedPath = resolveComfyUiPath({
+        config: storedConfig,
+        env: process.env,
+        platform: process.platform,
+    });
+
+    console.log(JSON.stringify({
+        configFile,
+        storedPath: storedConfig.path,
+        resolvedPath,
+    }, null, 2));
+}
+
+if (require.main === module) {
+    main();
+}

--- a/src/components/LocalModelManager.js
+++ b/src/components/LocalModelManager.js
@@ -253,6 +253,7 @@ function ModelCard(model, onStateChange) {
     const auxStatus = model.auxiliaryStatus || {};
     const auxReady = !model.requiresAuxiliary || (auxStatus.llm === 'downloaded' && auxStatus.vae === 'downloaded');
     const fullyReady = isDownloaded && auxReady;
+    const linkedFromComfyUi = model.linkedFrom?.provider === 'comfyui';
 
     card.innerHTML = `
         <div class="flex items-start justify-between gap-3">
@@ -260,6 +261,7 @@ function ModelCard(model, onStateChange) {
                 <div class="flex items-center gap-2 flex-wrap">
                     <span class="text-sm font-bold text-white truncate">${model.name}</span>
                     ${model.featured ? `<span class="px-1.5 py-0.5 rounded-md text-[10px] font-black bg-primary/20 text-primary border border-primary/30">⚡ Featured</span>` : ''}
+                    ${linkedFromComfyUi ? `<span class="px-1.5 py-0.5 rounded-md text-[10px] font-black bg-cyan-500/15 text-cyan-300 border border-cyan-400/20">Linked from ComfyUI</span>` : ''}
                     ${fullyReady ? `<span class="text-green-400">${CheckIcon}</span>` : ''}
                 </div>
                 <p class="text-[11px] text-muted leading-relaxed">${model.description}</p>
@@ -370,7 +372,7 @@ export function LocalModelManager() {
     modelsSection.innerHTML = `
         <div class="flex items-center justify-between">
             <h3 class="text-xs font-bold text-secondary uppercase tracking-wider">Local Models</h3>
-            <span class="text-[10px] text-muted">Stored in your app data folder</span>
+            <span class="text-[10px] text-muted">Downloaded or linked into your app data folder</span>
         </div>
         <div id="local-model-list" class="flex flex-col gap-3"></div>
     `;

--- a/tests/comfyUiIntegration.test.js
+++ b/tests/comfyUiIntegration.test.js
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+    getComfyUiConfigFile,
+    getDefaultComfyUiPath,
+    resolveComfyUiPath,
+} = require('../electron/lib/comfyUiConfig');
+const {
+    findComfyUiModelSource,
+    getComfyUiSearchPaths,
+} = require('../electron/lib/comfyUiCatalog');
+
+test('getDefaultComfyUiPath uses apps/ComfyUI on linux', () => {
+    const resolved = getDefaultComfyUiPath({
+        platform: 'linux',
+        homeDir: '/home/joes021',
+    });
+
+    assert.equal(resolved, '/home/joes021/apps/ComfyUI');
+});
+
+test('resolveComfyUiPath prefers env override, then config, then default', () => {
+    const envResolved = resolveComfyUiPath({
+        config: { path: '/configured/ComfyUI' },
+        env: { OPEN_GENERATIVE_AI_COMFYUI_PATH: '/env/ComfyUI' },
+        platform: 'linux',
+        homeDir: '/home/joes021',
+    });
+    const configResolved = resolveComfyUiPath({
+        config: { path: '/configured/ComfyUI' },
+        env: {},
+        platform: 'linux',
+        homeDir: '/home/joes021',
+    });
+    const defaultResolved = resolveComfyUiPath({
+        config: {},
+        env: {},
+        platform: 'linux',
+        homeDir: '/home/joes021',
+    });
+
+    assert.equal(envResolved, '/env/ComfyUI');
+    assert.equal(configResolved, '/configured/ComfyUI');
+    assert.equal(defaultResolved, '/home/joes021/apps/ComfyUI');
+});
+
+test('getComfyUiConfigFile stores config under the local-ai data dir', () => {
+    const configFile = getComfyUiConfigFile({
+        dataDir: '/home/joes021/.config/open-generative-ai/local-ai',
+        platform: 'linux',
+    });
+
+    assert.equal(configFile, '/home/joes021/.config/open-generative-ai/local-ai/comfyui.json');
+});
+
+test('getComfyUiSearchPaths includes aliases before generic fallback locations', () => {
+    const searchPaths = getComfyUiSearchPaths({
+        modelId: 'realistic-vision-v51',
+        filename: 'realisticVisionV51_v51VAE.safetensors',
+    });
+
+    assert.deepEqual(searchPaths.slice(0, 3), [
+        'models/checkpoints/Realistic_Vision_V5.1_fp16-no-ema.safetensors',
+        'models/checkpoints/realisticVisionV51_v51VAE.safetensors',
+        'models/diffusion_models/realisticVisionV51_v51VAE.safetensors',
+    ]);
+});
+
+test('findComfyUiModelSource finds supported checkpoint aliases inside ComfyUI', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'comfyui-model-'));
+    const comfyUiPath = path.join(tmpRoot, 'ComfyUI');
+    const aliasPath = path.join(comfyUiPath, 'models', 'checkpoints', 'Realistic_Vision_V5.1_fp16-no-ema.safetensors');
+    fs.mkdirSync(path.dirname(aliasPath), { recursive: true });
+    fs.writeFileSync(aliasPath, 'stub');
+
+    const sourcePath = findComfyUiModelSource({
+        comfyUiPath,
+        modelId: 'realistic-vision-v51',
+        filename: 'realisticVisionV51_v51VAE.safetensors',
+    });
+
+    assert.equal(sourcePath, aliasPath);
+});
+
+test('findComfyUiModelSource finds VAE auxiliary files in the VAE directory', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'comfyui-vae-'));
+    const comfyUiPath = path.join(tmpRoot, 'ComfyUI');
+    const vaePath = path.join(comfyUiPath, 'models', 'vae', 'ae.safetensors');
+    fs.mkdirSync(path.dirname(vaePath), { recursive: true });
+    fs.writeFileSync(vaePath, 'stub');
+
+    const sourcePath = findComfyUiModelSource({
+        modelId: '__vae__',
+        filename: 'ae.safetensors',
+        comfyUiPath,
+    });
+
+    assert.equal(sourcePath, vaePath);
+});

--- a/tests/localInferenceAssets.test.js
+++ b/tests/localInferenceAssets.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
     pickBinaryAssetForPlatform,
     getBundledBinaryResourceDir,
+    getLocalBinaryResourceDir,
 } = require('../electron/lib/localInferenceAssets');
 
 test('pickBinaryAssetForPlatform prefers native linux arm64 assets', () => {
@@ -32,5 +33,36 @@ test('getBundledBinaryResourceDir resolves linux arm64 bundled path', () => {
     assert.equal(
         bundledDir,
         '/opt/Open Generative AI/resources/local-ai/linux-arm64/bin'
+    );
+});
+
+test('getLocalBinaryResourceDir resolves unpackaged linux x64 staged path', () => {
+    const bundledDir = getLocalBinaryResourceDir({
+        appPath: '/home/joes021/codex/open-generative-ai',
+        resourcesPath: '/opt/Open Generative AI/resources',
+        isPackaged: false,
+        platform: 'linux',
+        arch: 'x64',
+    });
+
+    assert.equal(
+        bundledDir,
+        '/home/joes021/codex/open-generative-ai/build/local-ai/linux-x64/bin'
+    );
+});
+
+test('getLocalBinaryResourceDir prefers repo-relative module path for unpackaged runs', () => {
+    const bundledDir = getLocalBinaryResourceDir({
+        appPath: '/home/joes021/codex',
+        moduleDir: '/home/joes021/codex/open-generative-ai/electron/lib',
+        resourcesPath: '/opt/Open Generative AI/resources',
+        isPackaged: false,
+        platform: 'linux',
+        arch: 'x64',
+    });
+
+    assert.equal(
+        bundledDir,
+        '/home/joes021/codex/open-generative-ai/build/local-ai/linux-x64/bin'
     );
 });


### PR DESCRIPTION
## Summary
- support unpackaged Electron source runs by resolving staged `build/local-ai/<platform>-<arch>/bin` assets relative to the repo module path
- keep staged local runtime binaries out of git status by ignoring `build/local-ai/*` while keeping the checked-in README
- preserve the merged local inference packaging flow while making source smoke tests reproducible on Linux dev machines

## Root cause
After PR #172 merged, source Electron smoke tests on Linux still fell back to GitHub release downloads. The app was resolving staged local-ai assets from `app.getAppPath()`, which can point at the smoke harness directory instead of the repository root during unpackaged runs. Separately, staged runtime binaries were local build artifacts, so clean clones needed a restaging step and those artifacts should not pollute git status.

## Validation
- `node --test tests/localInferenceAssets.test.js tests/localInferenceProgress.test.js`
- Spark ARM64: source Electron smoke under `xvfb` after restaging `linux-arm64` binaries from the installed app
- r5950x x64: source Electron smoke under `xvfb` after restaging `linux-x64` binaries from the installed app