### PR TITLE
docs: clarify Muapi access key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Every image you upload is saved locally (URL + thumbnail) so you never upload th
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18+)
-- A [Muapi.ai](https://muapi.ai) API key
+- A [Muapi.ai access key](https://muapi.ai/access-keys). Copy the generated key value into the app; do not enter the key name or label.
 
 ### Setup
 

--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -13,26 +13,27 @@ export function AuthModal(onSuccess) {
                 </svg>
             </div>
             <h2 class="text-2xl font-black text-white uppercase tracking-wider mb-2">Muapi API Key Required</h2>
-            <p class="text-secondary text-sm">Please provide your Muapi.ai API key to start creating high-aesthetic images.</p>
+            <p class="text-secondary text-sm">Create a Muapi access key, then paste the key value here to start creating high-aesthetic images.</p>
         </div>
 
         <div class="space-y-6">
             <div class="space-y-2">
-                <label class="text-[10px] font-bold text-muted uppercase tracking-widest ml-1">Your API Key</label>
+                <label class="text-[10px] font-bold text-muted uppercase tracking-widest ml-1">Muapi Access Key</label>
                 <input 
                     type="password" 
                     id="muapi-key-input"
-                    placeholder="Enter your Muapi API key..."
+                    placeholder="Paste your access key value..."
                     class="w-full bg-black/40 border border-white/5 rounded-2xl px-5 py-4 text-white placeholder:text-muted focus:outline-none focus:border-primary/50 transition-colors shadow-inner"
                 >
+                <p class="text-[11px] text-muted ml-1">Do not enter the key name or label; paste the generated key value from Muapi.</p>
             </div>
 
             <div class="flex flex-col gap-3">
                 <button id="save-key-btn" class="w-full bg-primary text-black font-black py-4 rounded-2xl hover:shadow-glow hover:scale-[1.02] active:scale-[0.98] transition-all">
                     Initialize Studio
                 </button>
-                <a href="https://muapi.ai" target="_blank" class="text-center text-[11px] font-bold text-muted hover:text-white transition-colors py-2 uppercase tracking-tighter">
-                    Get an API Key at Muapi.ai →
+                <a href="https://muapi.ai/access-keys" target="_blank" rel="noreferrer" class="text-center text-[11px] font-bold text-muted hover:text-white transition-colors py-2 uppercase tracking-tighter">
+                    Create or copy a Muapi access key →
                 </a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Point the desktop/Vite API-key modal directly to the Muapi access-keys page instead of the generic Muapi homepage.
- Clarify that users should paste the generated access key value, not the key name or label.
- Add the same concrete access-key guidance to the README prerequisites.

## Why
Issue #157 shows a new user getting blocked at the API-key prompt and entering `Anil-matcha` as the key name because the existing desktop modal did not explain where to create/copy the actual key value. This keeps the fix narrow while making the onboarding path explicit.

Fixes #157

## Validation
- `node --check src/components/AuthModal.js`
- `git diff --check`

## Duplicate check
Checked open and recent PRs for `#157`, `API key`, `access key`, and `AuthModal`; I did not find an existing PR covering this guidance fix.