### PR TITLE
fix(security): validate and IP-pin proxy target on /api/upload-binary (SSRF)

### DIFF
--- a/app/api/upload-binary/route.js
+++ b/app/api/upload-binary/route.js
@@ -1,19 +1,32 @@
 import { NextResponse } from 'next/server';
+import { validateAndPinProxyTarget } from '../../lib/proxyTargetSafety.mjs';
 
 export async function POST(request) {
     try {
         const formData = await request.formData();
-        
+
         // Extract the original S3 target URL we injected earlier
-        const targetUrl = formData.get('x-proxy-target-url');
-        
-        if (!targetUrl) {
+        const rawTargetUrl = formData.get('x-proxy-target-url');
+
+        if (!rawTargetUrl) {
             return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
+        }
+
+        // Validate the URL so an attacker cannot turn this S3 helper into a
+        // generic SSRF gadget pointed at cloud metadata or internal services.
+        let target;
+        try {
+            target = await validateAndPinProxyTarget(String(rawTargetUrl));
+        } catch (err) {
+            return NextResponse.json(
+                { error: `Invalid proxy target: ${err.message}` },
+                { status: 400 }
+            );
         }
 
         // Reconstruct the FormData for S3 (excluding our internal proxy marker)
         const s3FormData = new FormData();
-        
+
         // S3 is very sensitive to field ordering. We must ensure 'file' is likely last
         // or at least that all signature fields come before what S3 expects.
         // The original library code appends 'file' last, so iterating should preserve that.
@@ -25,9 +38,10 @@ export async function POST(request) {
 
         // Perform the server-to-server POST to S3
         // This bypasses browser CORS/Preflight security entirely
-        const s3Response = await fetch(targetUrl, {
+        const s3Response = await fetch(target.url, {
             method: 'POST',
             body: s3FormData,
+            dispatcher: target.dispatcher,
         });
 
         if (s3Response.ok || s3Response.status === 204) {

--- a/app/api/v1/upload-binary/route.js
+++ b/app/api/v1/upload-binary/route.js
@@ -1,14 +1,27 @@
 import { NextResponse } from 'next/server';
+import { validateAndPinProxyTarget } from '../../../lib/proxyTargetSafety.mjs';
 
 export async function POST(request) {
     try {
         const formData = await request.formData();
-        
+
         // Extract the original S3 target URL
-        const targetUrl = formData.get('x-proxy-target-url');
-        
-        if (!targetUrl) {
+        const rawTargetUrl = formData.get('x-proxy-target-url');
+
+        if (!rawTargetUrl) {
             return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
+        }
+
+        // Validate the URL so an attacker cannot turn this S3 helper into a
+        // generic SSRF gadget pointed at cloud metadata or internal services.
+        let target;
+        try {
+            target = await validateAndPinProxyTarget(String(rawTargetUrl));
+        } catch (err) {
+            return NextResponse.json(
+                { error: `Invalid proxy target: ${err.message}` },
+                { status: 400 }
+            );
         }
 
         const s3FormData = new FormData();
@@ -18,9 +31,10 @@ export async function POST(request) {
             }
         }
 
-        const s3Response = await fetch(targetUrl, {
+        const s3Response = await fetch(target.url, {
             method: 'POST',
             body: s3FormData,
+            dispatcher: target.dispatcher,
         });
 
         if (s3Response.ok || s3Response.status === 204) {

--- a/app/lib/proxyTargetSafety.mjs
+++ b/app/lib/proxyTargetSafety.mjs
@@ -1,0 +1,208 @@
+// Server-side validator + IP-pinned dispatcher for fetches whose target URL
+// is supplied by the client (the upload-binary proxy routes).
+//
+// Without this, /api/upload-binary and /api/v1/upload-binary accept any URL
+// in the x-proxy-target-url form field and POST to it server-side, which is
+// a textbook SSRF (cloud metadata, internal admin APIs, etc.). The intended
+// targets are S3 presigned URLs returned by the upstream MuAPI service.
+//
+// Defense in depth:
+//   1. Require https://
+//   2. Reject embedded credentials
+//   3. Reject literal IPs in private / loopback / link-local / cloud-metadata
+//      ranges (covers IPv4, IPv4-mapped IPv6, IPv4-compatible IPv6, IPv6 ULA,
+//      IPv6 link-local, multicast, CGNAT 100.64.0.0/10).
+//   4. DNS-resolve the hostname and reject the request if *any* returned
+//      address falls in those same ranges.
+//   5. Pin the connection to the validated IP via an undici Agent so that a
+//      racing DNS flip between validation and fetch cannot redirect the
+//      request to a private IP (canonical DNS-rebinding defense).
+//   6. Optional operator allowlist via PROXY_TARGET_ALLOWED_HOSTS — comma-
+//      separated host suffixes (e.g. "s3.amazonaws.com,storage.googleapis.com").
+//      When set, only hostnames matching one of the suffixes are accepted.
+
+import dns from 'node:dns/promises';
+import net from 'node:net';
+import { Agent } from 'undici';
+
+const IPV4_BLOCKED_RANGES = [
+    [0x0A000000, 0xFF000000], // 10.0.0.0/8
+    [0xAC100000, 0xFFF00000], // 172.16.0.0/12
+    [0xC0A80000, 0xFFFF0000], // 192.168.0.0/16
+    [0x7F000000, 0xFF000000], // 127.0.0.0/8 loopback
+    [0xA9FE0000, 0xFFFF0000], // 169.254.0.0/16 link-local + cloud metadata
+    [0x64400000, 0xFFC00000], // 100.64.0.0/10 CGNAT
+    [0x00000000, 0xFF000000], // 0.0.0.0/8 "this" network
+    [0xC0000200, 0xFFFFFF00], // 192.0.2.0/24 TEST-NET-1
+    [0xC6336400, 0xFFFFFF00], // 198.51.100.0/24 TEST-NET-2
+    [0xCB007100, 0xFFFFFF00], // 203.0.113.0/24 TEST-NET-3
+    [0xE0000000, 0xF0000000], // 224.0.0.0/4 multicast
+    [0xF0000000, 0xF0000000], // 240.0.0.0/4 reserved
+    [0xFFFFFFFF, 0xFFFFFFFF], // 255.255.255.255 broadcast
+];
+
+function ipv4ToInt(addr) {
+    const parts = addr.split('.');
+    if (parts.length !== 4) return null;
+    let n = 0;
+    for (const p of parts) {
+        const v = Number(p);
+        if (!Number.isInteger(v) || v < 0 || v > 255) return null;
+        n = (n * 256) + v;
+    }
+    return n >>> 0;
+}
+
+export function isPrivateIPv4(addr) {
+    const n = ipv4ToInt(addr);
+    if (n === null) return true; // malformed — fail closed
+    return IPV4_BLOCKED_RANGES.some(([base, mask]) => (n & mask) === (base & mask));
+}
+
+export function isPrivateIPv6(addr) {
+    const lower = addr.toLowerCase();
+
+    // Loopback / unspecified
+    if (lower === '::1' || lower === '::') return true;
+
+    // Multicast ff00::/8
+    if (lower.startsWith('ff')) return true;
+
+    // Unique local fc00::/7 — first byte 0xfc or 0xfd
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+
+    // Link-local fe80::/10 — first 10 bits are 1111111010 → fe8x..feax/feax..febx
+    if (lower.startsWith('fe8') || lower.startsWith('fe9') ||
+        lower.startsWith('fea') || lower.startsWith('feb')) return true;
+
+    // IPv4-mapped / IPv4-compatible in dotted form (e.g. ::ffff:169.254.169.254)
+    const dottedMapped = lower.match(/^::(ffff(:0)?:)?(\d+\.\d+\.\d+\.\d+)$/);
+    if (dottedMapped && dottedMapped[3]) {
+        return isPrivateIPv4(dottedMapped[3]);
+    }
+
+    // IPv4-mapped in hex form — Node's URL parser normalizes
+    // ::ffff:169.254.169.254 → ::ffff:a9fe:a9fe, so we have to recognize this.
+    const hexMapped = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (hexMapped) {
+        const wrapped = hexGroupsToIpv4(hexMapped[1], hexMapped[2]);
+        if (wrapped) return isPrivateIPv4(wrapped);
+    }
+
+    // IPv4-compatible in hex form (deprecated but still represents an IPv4)
+    const hexCompat = lower.match(/^::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (hexCompat) {
+        const wrapped = hexGroupsToIpv4(hexCompat[1], hexCompat[2]);
+        if (wrapped) return isPrivateIPv4(wrapped);
+    }
+
+    // 6to4 2002::/16 — wrapped IPv4 in first 32 bits; reject if wrapped IPv4 is private
+    if (lower.startsWith('2002:')) {
+        const parts = lower.split(':');
+        if (parts.length >= 3) {
+            const wrapped = hexGroupsToIpv4(parts[1] || '0', parts[2] || '0');
+            if (wrapped && isPrivateIPv4(wrapped)) return true;
+        }
+    }
+
+    return false;
+}
+
+function hexGroupsToIpv4(hiStr, loStr) {
+    const hi = parseInt(hiStr || '0', 16);
+    const lo = parseInt(loStr || '0', 16);
+    if (!Number.isFinite(hi) || !Number.isFinite(lo)) return null;
+    return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+export function isPrivateAddress(addr, family) {
+    if (family === 4) return isPrivateIPv4(addr);
+    if (family === 6) return isPrivateIPv6(addr);
+    return true; // unknown family — fail closed
+}
+
+function getAllowlist() {
+    const raw = process.env.PROXY_TARGET_ALLOWED_HOSTS;
+    if (!raw) return null;
+    return raw.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+}
+
+function hostnameAllowed(hostname, allowlist) {
+    if (!allowlist) return true;
+    const h = hostname.toLowerCase();
+    return allowlist.some(suffix => h === suffix || h.endsWith('.' + suffix));
+}
+
+function stripBrackets(hostname) {
+    return hostname.startsWith('[') && hostname.endsWith(']')
+        ? hostname.slice(1, -1)
+        : hostname;
+}
+
+function buildPinnedDispatcher(address, family) {
+    return new Agent({
+        connect: {
+            lookup: (_hostname, _opts, cb) => cb(null, address, family),
+        },
+    });
+}
+
+export async function validateAndPinProxyTarget(rawUrl, lookupFn = dns.lookup) {
+    if (typeof rawUrl !== 'string' || rawUrl.length === 0) {
+        throw new Error('proxy target URL is required');
+    }
+    let u;
+    try {
+        u = new URL(rawUrl);
+    } catch {
+        throw new Error('proxy target URL is not a valid URL');
+    }
+
+    if (u.protocol !== 'https:') {
+        throw new Error(`proxy target URL must use https (got ${u.protocol})`);
+    }
+    if (u.username || u.password) {
+        throw new Error('proxy target URL must not embed credentials');
+    }
+
+    const bareHost = stripBrackets(u.hostname);
+
+    const allowlist = getAllowlist();
+    if (!hostnameAllowed(bareHost, allowlist)) {
+        throw new Error(`proxy target host is not in PROXY_TARGET_ALLOWED_HOSTS allowlist`);
+    }
+
+    // 1. Literal IP in the hostname → validate directly, no DNS.
+    if (net.isIP(bareHost)) {
+        const family = net.isIPv6(bareHost) ? 6 : 4;
+        if (isPrivateAddress(bareHost, family)) {
+            throw new Error(`proxy target resolves to a non-public IP (${bareHost})`);
+        }
+        return { url: u.toString(), dispatcher: buildPinnedDispatcher(bareHost, family) };
+    }
+
+    // 2. DNS hostname → resolve and verify every record.
+    let records;
+    try {
+        records = await lookupFn(bareHost, { all: true, verbatim: true });
+    } catch (err) {
+        throw new Error(`proxy target hostname did not resolve: ${err.code || err.message}`);
+    }
+    if (!Array.isArray(records) || records.length === 0) {
+        throw new Error('proxy target hostname did not resolve to any address');
+    }
+    for (const r of records) {
+        if (isPrivateAddress(r.address, r.family)) {
+            throw new Error(`proxy target resolves to a non-public IP (${r.address})`);
+        }
+    }
+
+    // 3. Pin the connection to the first validated record so a racing DNS
+    //    flip cannot redirect the request to a private IP between this check
+    //    and the fetch dispatch.
+    const pinned = records[0];
+    return {
+        url: u.toString(),
+        dispatcher: buildPinnedDispatcher(pinned.address, pinned.family),
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.4.1",
         "studio": "*",
+        "undici": "^6.21.0",
         "workflow-builder": "file:./packages/Vibe-Workflow/packages/workflow-builder"
       },
       "devDependencies": {
@@ -120,7 +121,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4999,7 +4999,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -5587,7 +5586,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5652,7 +5650,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5879,6 +5876,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -5898,6 +5896,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -5919,7 +5918,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -5927,6 +5927,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -5942,7 +5943,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5950,6 +5952,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -6497,7 +6500,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7162,6 +7164,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -7300,6 +7303,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -7313,6 +7317,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -7353,8 +7358,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -7413,7 +7417,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7739,7 +7742,6 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -7947,6 +7949,7 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -7960,6 +7963,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -7975,6 +7979,7 @@
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -7988,6 +7993,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -8399,7 +8405,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8573,7 +8578,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9154,7 +9158,8 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -10737,8 +10742,7 @@
           "url": "https://github.com/sponsors/lavrton"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -10773,6 +10777,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -10785,7 +10790,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -10793,6 +10799,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10808,7 +10815,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -10816,6 +10824,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11150,28 +11159,32 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -11185,7 +11198,8 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -12565,7 +12579,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
       "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
@@ -12618,7 +12631,6 @@
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
       "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
@@ -13329,7 +13341,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13519,7 +13530,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -13643,7 +13655,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13653,7 +13664,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13872,6 +13882,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -13882,6 +13893,7 @@
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -13892,6 +13904,7 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -15378,6 +15391,7 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -15512,7 +15526,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15746,7 +15759,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15772,6 +15784,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -16097,7 +16118,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -16430,6 +16450,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -16445,6 +16466,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.4.1",
     "studio": "*",
+    "undici": "^6.21.0",
     "workflow-builder": "file:./packages/Vibe-Workflow/packages/workflow-builder",
     "ai-agent": "file:./packages/Open-Poe-AI/packages/agents"
   },

--- a/tests/proxyTargetSafety.test.mjs
+++ b/tests/proxyTargetSafety.test.mjs
@@ -1,0 +1,247 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    isPrivateIPv4,
+    isPrivateIPv6,
+    isPrivateAddress,
+    validateAndPinProxyTarget,
+} from '../app/lib/proxyTargetSafety.mjs';
+
+// --- IPv4 range coverage ---
+
+test('isPrivateIPv4 rejects loopback', () => {
+    assert.equal(isPrivateIPv4('127.0.0.1'), true);
+    assert.equal(isPrivateIPv4('127.255.255.254'), true);
+});
+
+test('isPrivateIPv4 rejects RFC1918 ranges', () => {
+    assert.equal(isPrivateIPv4('10.0.0.1'), true);
+    assert.equal(isPrivateIPv4('10.255.255.255'), true);
+    assert.equal(isPrivateIPv4('172.16.0.1'), true);
+    assert.equal(isPrivateIPv4('172.31.255.255'), true);
+    assert.equal(isPrivateIPv4('192.168.1.1'), true);
+});
+
+test('isPrivateIPv4 rejects link-local and cloud metadata 169.254.0.0/16', () => {
+    assert.equal(isPrivateIPv4('169.254.0.1'), true);
+    assert.equal(isPrivateIPv4('169.254.169.254'), true); // AWS / GCP metadata
+});
+
+test('isPrivateIPv4 rejects CGNAT 100.64.0.0/10', () => {
+    assert.equal(isPrivateIPv4('100.64.0.1'), true);
+    assert.equal(isPrivateIPv4('100.127.255.254'), true);
+    // 100.63.x and 100.128.x are public
+    assert.equal(isPrivateIPv4('100.63.255.255'), false);
+    assert.equal(isPrivateIPv4('100.128.0.1'), false);
+});
+
+test('isPrivateIPv4 rejects 0.0.0.0/8 and broadcast', () => {
+    assert.equal(isPrivateIPv4('0.0.0.0'), true);
+    assert.equal(isPrivateIPv4('0.1.2.3'), true);
+    assert.equal(isPrivateIPv4('255.255.255.255'), true);
+});
+
+test('isPrivateIPv4 rejects multicast 224.0.0.0/4 and reserved 240.0.0.0/4', () => {
+    assert.equal(isPrivateIPv4('224.0.0.1'), true);
+    assert.equal(isPrivateIPv4('239.255.255.255'), true);
+    assert.equal(isPrivateIPv4('240.0.0.1'), true);
+});
+
+test('isPrivateIPv4 fails closed on malformed input', () => {
+    assert.equal(isPrivateIPv4('not.an.ip.address'), true);
+    assert.equal(isPrivateIPv4('1.2.3'), true);
+    assert.equal(isPrivateIPv4(''), true);
+});
+
+test('isPrivateIPv4 accepts public addresses', () => {
+    assert.equal(isPrivateIPv4('8.8.8.8'), false);
+    assert.equal(isPrivateIPv4('1.1.1.1'), false);
+    assert.equal(isPrivateIPv4('52.84.150.39'), false); // representative public AWS CloudFront IP
+});
+
+// --- IPv6 range coverage ---
+
+test('isPrivateIPv6 rejects loopback and unspecified', () => {
+    assert.equal(isPrivateIPv6('::1'), true);
+    assert.equal(isPrivateIPv6('::'), true);
+});
+
+test('isPrivateIPv6 rejects ULA fc00::/7', () => {
+    assert.equal(isPrivateIPv6('fc00::1'), true);
+    assert.equal(isPrivateIPv6('fd12:3456:789a::1'), true);
+});
+
+test('isPrivateIPv6 rejects link-local fe80::/10', () => {
+    assert.equal(isPrivateIPv6('fe80::1'), true);
+    assert.equal(isPrivateIPv6('feb0::1'), true);
+});
+
+test('isPrivateIPv6 rejects multicast', () => {
+    assert.equal(isPrivateIPv6('ff02::1'), true);
+});
+
+test('isPrivateIPv6 rejects IPv4-mapped private addresses', () => {
+    assert.equal(isPrivateIPv6('::ffff:127.0.0.1'), true);
+    assert.equal(isPrivateIPv6('::ffff:169.254.169.254'), true);
+    assert.equal(isPrivateIPv6('::ffff:10.0.0.1'), true);
+});
+
+test('isPrivateIPv6 rejects IPv4-compatible private addresses', () => {
+    assert.equal(isPrivateIPv6('::127.0.0.1'), true);
+});
+
+test('isPrivateIPv6 rejects 6to4 wrapping private IPv4', () => {
+    // 2002:a00:1:: wraps 10.0.0.1 (0x0a000001 → ::a:0:1::)
+    assert.equal(isPrivateIPv6('2002:a00:1::'), true);
+    // 2002:7f00:1:: wraps 127.0.0.1
+    assert.equal(isPrivateIPv6('2002:7f00:1::'), true);
+});
+
+test('isPrivateIPv6 accepts public addresses', () => {
+    assert.equal(isPrivateIPv6('2001:4860:4860::8888'), false); // Google DNS
+    assert.equal(isPrivateIPv6('2606:4700:4700::1111'), false); // Cloudflare DNS
+});
+
+// --- isPrivateAddress dispatcher ---
+
+test('isPrivateAddress fails closed on unknown family', () => {
+    assert.equal(isPrivateAddress('1.2.3.4', 0), true);
+    assert.equal(isPrivateAddress('1.2.3.4', undefined), true);
+});
+
+// --- validateAndPinProxyTarget end-to-end ---
+
+const fakeLookupReturning = (records) => async () => records;
+const fakeLookupThrowing = (err) => async () => { throw err; };
+
+test('rejects non-string and empty input', async () => {
+    await assert.rejects(() => validateAndPinProxyTarget(undefined), /required/);
+    await assert.rejects(() => validateAndPinProxyTarget(''), /required/);
+    await assert.rejects(() => validateAndPinProxyTarget(null), /required/);
+});
+
+test('rejects malformed URLs', async () => {
+    await assert.rejects(() => validateAndPinProxyTarget('not a url'), /not a valid URL/);
+});
+
+test('rejects non-https schemes', async () => {
+    await assert.rejects(() => validateAndPinProxyTarget('http://example.com/'), /must use https/);
+    await assert.rejects(() => validateAndPinProxyTarget('file:///etc/passwd'), /must use https/);
+    await assert.rejects(() => validateAndPinProxyTarget('ftp://example.com/'), /must use https/);
+});
+
+test('rejects URLs with embedded credentials', async () => {
+    const lookup = fakeLookupReturning([{ address: '8.8.8.8', family: 4 }]);
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://attacker:secret@example.com/path', lookup),
+        /must not embed credentials/
+    );
+});
+
+test('rejects literal private IPv4 hostnames without DNS', async () => {
+    const lookup = async () => { throw new Error('DNS should not be consulted'); };
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://169.254.169.254/latest/meta-data/', lookup),
+        /non-public IP/
+    );
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://127.0.0.1/admin', lookup),
+        /non-public IP/
+    );
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://10.0.0.5/internal', lookup),
+        /non-public IP/
+    );
+});
+
+test('rejects literal private IPv6 hostnames without DNS', async () => {
+    const lookup = async () => { throw new Error('DNS should not be consulted'); };
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://[::1]/admin', lookup),
+        /non-public IP/
+    );
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://[::ffff:169.254.169.254]/', lookup),
+        /non-public IP/
+    );
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://[fc00::1]/', lookup),
+        /non-public IP/
+    );
+});
+
+test('rejects hostnames that resolve to private IPs (DNS rebinding gate)', async () => {
+    const lookup = fakeLookupReturning([
+        { address: '8.8.8.8', family: 4 },
+        { address: '127.0.0.1', family: 4 }, // mixed answer set — one bad record poisons the whole lookup
+    ]);
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://attacker.example/', lookup),
+        /non-public IP/
+    );
+});
+
+test('rejects DNS resolution failure', async () => {
+    const lookup = fakeLookupThrowing(Object.assign(new Error('nope'), { code: 'ENOTFOUND' }));
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://does-not-resolve.example/', lookup),
+        /did not resolve/
+    );
+});
+
+test('rejects DNS resolution returning empty list', async () => {
+    const lookup = fakeLookupReturning([]);
+    await assert.rejects(
+        () => validateAndPinProxyTarget('https://no-records.example/', lookup),
+        /did not resolve to any address/
+    );
+});
+
+test('accepts public HTTPS URL resolving to a public IP', async () => {
+    const lookup = fakeLookupReturning([{ address: '52.84.150.39', family: 4 }]);
+    const out = await validateAndPinProxyTarget(
+        'https://demo.s3.amazonaws.com/upload/abc?X-Amz-Signature=xyz',
+        lookup
+    );
+    assert.equal(typeof out.url, 'string');
+    assert.match(out.url, /^https:\/\/demo\.s3\.amazonaws\.com\//);
+    assert.ok(out.dispatcher, 'pinned dispatcher should be returned');
+});
+
+test('accepts public HTTPS URL with literal public IPv6', async () => {
+    const lookup = async () => { throw new Error('DNS should not be consulted'); };
+    const out = await validateAndPinProxyTarget(
+        'https://[2606:4700:4700::1111]/path',
+        lookup
+    );
+    assert.equal(typeof out.url, 'string');
+    assert.ok(out.dispatcher);
+});
+
+test('PROXY_TARGET_ALLOWED_HOSTS env restricts which hostnames are allowed', async () => {
+    const original = process.env.PROXY_TARGET_ALLOWED_HOSTS;
+    try {
+        process.env.PROXY_TARGET_ALLOWED_HOSTS = 's3.amazonaws.com,storage.googleapis.com';
+        const lookup = fakeLookupReturning([{ address: '52.84.150.39', family: 4 }]);
+
+        // matches s3.amazonaws.com suffix → allowed
+        const ok = await validateAndPinProxyTarget(
+            'https://my-bucket.s3.amazonaws.com/upload',
+            lookup
+        );
+        assert.match(ok.url, /amazonaws\.com/);
+
+        // not in allowlist → rejected even though IP is public
+        await assert.rejects(
+            () => validateAndPinProxyTarget('https://evil.example/upload', lookup),
+            /allowlist/
+        );
+    } finally {
+        if (original === undefined) {
+            delete process.env.PROXY_TARGET_ALLOWED_HOSTS;
+        } else {
+            process.env.PROXY_TARGET_ALLOWED_HOSTS = original;
+        }
+    }
+});


### PR DESCRIPTION
## Summary

`/api/upload-binary` and `/api/v1/upload-binary` are server-side proxies that accept any URL in the `x-proxy-target-url` form field and `POST` FormData to it. The intent is to forward to S3 presigned URLs the upstream MuAPI service returns, but with no validation those endpoints are generic SSRF gadgets — an attacker can point them at cloud metadata (`http://169.254.169.254/...`), internal admin APIs, RFC1918 hosts, or any URL the Next.js server can reach. The server returns the upstream response body to the caller on non-2xx, which leaks internal error pages back to the attacker too.

This PR adds a shared validator (`app/lib/proxyTargetSafety.mjs`) that both routes call before `fetch`, and pins the connection to a validated IP via an `undici` Agent so a DNS-rebinding race can't redirect the request after validation.

## Impact

Concretely, before this change, anyone who can reach the deployment can do:

```
curl -X POST https://<host>/api/upload-binary \
  -F 'x-proxy-target-url=http://169.254.169.254/latest/meta-data/iam/security-credentials/' \
  -F 'noise=1'
```

…and have the Next.js server execute that fetch from inside its network boundary. On a non-2xx the response body is echoed back; on a 2xx the request still happens server-side (useful for triggering destructive POSTs against internal-only services, port-scanning by status/timing, etc.). Cloud metadata, internal Kubernetes services, intranet admin panels — anything the server's network reaches is in scope.

Severity: **HIGH** (CWE-918 SSRF, with CWE-350 / CWE-346 DNS rebinding mitigation as defense-in-depth).

## Location

- `app/api/upload-binary/route.js`
- `app/api/v1/upload-binary/route.js`

Both files read `x-proxy-target-url` from the multipart form and call `fetch(targetUrl, …)` without any validation of scheme, host, or resolved IP.

## Fix

New helper `app/lib/proxyTargetSafety.mjs` exports `validateAndPinProxyTarget(rawUrl)`. The route handlers call it before `fetch`:

```js
let target;
try {
    target = await validateAndPinProxyTarget(String(rawTargetUrl));
} catch (err) {
    return NextResponse.json({ error: `Invalid proxy target: ${err.message}` }, { status: 400 });
}

const s3Response = await fetch(target.url, {
    method: 'POST',
    body: s3FormData,
    dispatcher: target.dispatcher,
});
```

The validator enforces, in order:

1. `https://` only (blocks `http://`, `file://`, `ftp://`, …).
2. No embedded credentials (`https://attacker:secret@example.com/...`).
3. Literal-IP hostnames are checked directly against private / loopback / link-local / cloud-metadata / CGNAT / multicast / reserved ranges — covering IPv4, IPv4-mapped IPv6 in both dotted and hex-normalized forms (Node's URL parser canonicalizes `[::ffff:169.254.169.254]` → `[::ffff:a9fe:a9fe]`, the validator handles both), IPv4-compatible IPv6, IPv6 ULA (`fc00::/7`), IPv6 link-local (`fe80::/10`), IPv6 multicast (`ff00::/8`), and 2002::/16 6to4 wrapping a private IPv4.
4. DNS hostnames are resolved with `dns.lookup({ all: true })`; if any returned record is in the same blocked ranges, the request is rejected.
5. The connection is pinned to the validated IP via an `undici` `Agent` with a custom `connect.lookup` so a racing DNS flip between the validator and the actual `fetch` can't redirect the request to a private IP (canonical DNS-rebinding defense).
6. Optional operator allowlist via `PROXY_TARGET_ALLOWED_HOSTS` (comma-separated host suffixes, e.g. `s3.amazonaws.com,storage.googleapis.com`) for deployments that want to scope the endpoint to a known storage-provider list.

`undici` is added as an explicit dependency (Node 18+ ships it internally but doesn't expose it as a built-in module).

## Detected by

Aeon + manual review of `app/api/*/route.js`.

- Severity: HIGH
- CWE-918 (SSRF) with CWE-350 / CWE-346 DNS rebinding hardening as defense-in-depth.

## Verification

- 29 new unit tests in `tests/proxyTargetSafety.test.mjs` covering every IPv4/IPv6 range, IPv4-mapped IPv6 in both forms, 6to4, DNS rebinding, allowlist behavior, malformed input, and the happy path.
- `node --test tests/*.test.js tests/*.test.mjs` → 41/41 pass (12 pre-existing localInference tests + 29 new SSRF tests). No regressions.
- The two route handlers preserve their original behavior on the happy path: well-formed `https://*.s3.amazonaws.com/...` presigned URLs round-trip through unchanged; only the SSRF surface is closed.

## Notes for maintainers

- The validator returns `{ url, dispatcher }`; both routes pass `dispatcher: target.dispatcher` to `fetch`. This works in Next.js Route Handlers (Node.js runtime) because Node's global `fetch` accepts undici dispatchers. If you ever move these routes to the Edge runtime, the dispatcher path will need a different shape — flagging it here as a forward note rather than a current issue.
- `PROXY_TARGET_ALLOWED_HOSTS` is opt-in (undefined → all public hosts allowed). If you want stricter behavior in production, setting it to `s3.amazonaws.com` (and whatever storage hostname MuAPI actually hands back) tightens this further without code changes.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
