### PR TITLE
fix(local-ai): show startup heartbeat while models load

### DIFF
--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -9,6 +9,7 @@ const {
     pickBinaryAssetForPlatform,
 } = require('./localInferenceAssets');
 const {
+    formatStartupProgressMessage,
     parseGenerationProgressChunk,
     resolveGenerationSteps,
     resolveGuidanceScale,
@@ -481,7 +482,30 @@ async function generate(params, mainWindow) {
     }
 
     return new Promise((resolve, reject) => {
-        send({ step: 0, totalSteps: steps, status: 'starting', progress: 0 });
+        const startupStartedAt = Date.now();
+        let startupHeartbeat = null;
+        let samplingStarted = false;
+
+        const sendStartupProgress = () => {
+            send({
+                step: 0,
+                totalSteps: steps,
+                status: 'starting',
+                progress: 0,
+                message: formatStartupProgressMessage(Date.now() - startupStartedAt),
+            });
+        };
+        const stopStartupHeartbeat = () => {
+            if (startupHeartbeat) {
+                clearInterval(startupHeartbeat);
+                startupHeartbeat = null;
+            }
+        };
+
+        sendStartupProgress();
+        startupHeartbeat = setInterval(() => {
+            if (!samplingStarted) sendStartupProgress();
+        }, 5000);
 
         console.log('[sd-cli] command:', BINARY_PATH, args.join(' '));
         // DYLD_LIBRARY_PATH lets macOS find libstable-diffusion.dylib next to sd-cli
@@ -495,6 +519,8 @@ async function generate(params, mainWindow) {
             outputLines.push(line.trimEnd());
             const progressEvents = parseGenerationProgressChunk(line, progressState);
             for (const event of progressEvents) {
+                samplingStarted = true;
+                stopStartupHeartbeat();
                 send({ ...event, status: 'generating' });
             }
         };
@@ -503,6 +529,7 @@ async function generate(params, mainWindow) {
         activeProcess.stderr.on('data', handleOutput);
 
         activeProcess.on('close', (code) => {
+            stopStartupHeartbeat();
             activeProcess = null;
             const allOutput = outputLines.filter(l => l.trim()).join('\n');
             console.error('[sd-cli] full output:\n' + allOutput);
@@ -527,6 +554,7 @@ async function generate(params, mainWindow) {
         });
 
         activeProcess.on('error', (err) => {
+            stopStartupHeartbeat();
             activeProcess = null;
             reject(err);
         });

--- a/electron/lib/localInferenceRuntime.js
+++ b/electron/lib/localInferenceRuntime.js
@@ -28,6 +28,16 @@ function resolveGuidanceScale(params, model) {
     return 7.5;
 }
 
+function formatStartupProgressMessage(elapsedMs) {
+    const seconds = Math.max(0, Math.floor((Number(elapsedMs) || 0) / 1000));
+    if (seconds < 10) return 'Starting local model...';
+    if (seconds < 60) return `Loading local model (${seconds}s)...`;
+
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `Loading local model (${minutes}m ${remainingSeconds}s)...`;
+}
+
 function stripAnsiSequences(text) {
     return text.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
@@ -86,6 +96,7 @@ function parseGenerationProgressChunk(chunk, state = { tail: '', lastStep: 0, la
 module.exports = {
     coerceFiniteNumber,
     extractProgressEvents,
+    formatStartupProgressMessage,
     parseGenerationProgressChunk,
     resolveGenerationSteps,
     resolveGuidanceScale,

--- a/src/components/ImageStudio.js
+++ b/src/components/ImageStudio.js
@@ -1183,11 +1183,12 @@ export function ImageStudio() {
             progressWrap.classList.remove('hidden');
             progressWrap.classList.add('flex');
 
-            const unsub = localAI.onProgress(({ progress, status }) => {
+            const unsub = localAI.onProgress(({ progress, status, message }) => {
                 const pct = Math.round((progress ?? 0) * 100);
+                const label = message || (status === 'starting' ? 'Starting...' : `${pct}%`);
                 if (progressFill) progressFill.style.width = `${pct}%`;
-                if (progressPct) progressPct.textContent = status === 'starting' ? 'Starting...' : `${pct}%`;
-                generateBtn.innerHTML = `<span class="animate-spin inline-block mr-2 text-black">◌</span> ${status === 'starting' ? '...' : pct + '%'}`;
+                if (progressPct) progressPct.textContent = label;
+                generateBtn.innerHTML = `<span class="animate-spin inline-block mr-2 text-black">◌</span> ${label}`;
             });
 
             let hadError = false;

--- a/src/components/VideoStudio.js
+++ b/src/components/VideoStudio.js
@@ -1133,9 +1133,10 @@ export function VideoStudio() {
         // For local generations, surface step progress in the button label.
         let unsubscribeProgress = null;
         if (isLocal) {
-            unsubscribeProgress = localAI.onProgress(({ status, progress }) => {
+            unsubscribeProgress = localAI.onProgress(({ status, progress, message }) => {
                 const pct = typeof progress === 'number' ? Math.round(progress * 100) : null;
-                generateBtn.innerHTML = `<span class="animate-spin inline-block mr-2 text-black">◌</span> ${status || t('common.generating')}${pct != null ? ` ${pct}%` : '…'}`;
+                const label = message || `${status || t('common.generating')}${pct != null ? ` ${pct}%` : '...'}`;
+                generateBtn.innerHTML = `<span class="animate-spin inline-block mr-2 text-black">◌</span> ${label}`;
             });
         }
 

--- a/tests/localInferenceProgress.test.js
+++ b/tests/localInferenceProgress.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+    formatStartupProgressMessage,
     parseGenerationProgressChunk,
     resolveGenerationSteps,
     resolveGuidanceScale,
@@ -21,6 +22,12 @@ test('resolveGuidanceScale prefers explicit request over model defaults', () => 
 test('stripAnsiSequences removes terminal control codes', () => {
     const cleaned = stripAnsiSequences('\u001b[32mhello\u001b[0m');
     assert.equal(cleaned, 'hello');
+});
+
+test('formatStartupProgressMessage surfaces elapsed startup time', () => {
+    assert.equal(formatStartupProgressMessage(0), 'Starting local model...');
+    assert.equal(formatStartupProgressMessage(12_400), 'Loading local model (12s)...');
+    assert.equal(formatStartupProgressMessage(65_000), 'Loading local model (1m 5s)...');
 });
 
 test('parseGenerationProgressChunk extracts sd-cli sampling progress from carriage-return output', () => {


### PR DESCRIPTION
## Summary
- Emit a local sd.cpp startup heartbeat every 5 seconds until sampling progress starts.
- Include elapsed-time messages such as `Loading local model (12s)...` so the UI no longer appears stuck on `Starting...` while large local models load.
- Surface those progress messages in the Image and Video studio buttons/progress labels.

## Why
Refs #168. Local generation can spend a noticeable amount of time loading large model files before `sd-cli` starts printing step progress. During that window the UI only shows `Starting...`, which makes it hard to tell whether the job is still alive or stuck.

This keeps the existing progress parsing path unchanged once sampling begins; it only improves the pre-sampling startup phase.

## Validation
- `node --test tests/localInferenceAssets.test.js tests/localInferencePaths.test.js tests/localInferenceProgress.test.js tests/wan2gpModelAvailability.test.js` (17 pass)
- `node --check electron/lib/localInferenceRuntime.js`
- `node --check electron/lib/localInference.js`
- `node --check src/components/ImageStudio.js`
- `node --check src/components/VideoStudio.js`
- `git diff --check`

## Duplicate check
Searched open and recent PRs/issues for local generation startup/status/progress overlap; I did not find an existing PR covering the `stuck on Starting...` part of #168.