### PR TITLE
Validate upload proxy target URL to prevent SSRF

### DIFF
--- a/app/api/upload-binary/route.js
+++ b/app/api/upload-binary/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { validateUploadProxyTarget } from '../../../src/lib/uploadProxyTarget';
 
 export async function POST(request) {
     try {
@@ -9,6 +10,14 @@ export async function POST(request) {
         
         if (!targetUrl) {
             return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
+        }
+
+        const validatedTarget = validateUploadProxyTarget(targetUrl);
+        if (!validatedTarget.ok) {
+            return NextResponse.json(
+                { error: 'Invalid upload target', reason: validatedTarget.reason },
+                { status: 400 }
+            );
         }
 
         // Reconstruct the FormData for S3 (excluding our internal proxy marker)
@@ -25,7 +34,7 @@ export async function POST(request) {
 
         // Perform the server-to-server POST to S3
         // This bypasses browser CORS/Preflight security entirely
-        const s3Response = await fetch(targetUrl, {
+        const s3Response = await fetch(validatedTarget.url, {
             method: 'POST',
             body: s3FormData,
         });

--- a/app/api/v1/upload-binary/route.js
+++ b/app/api/v1/upload-binary/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { validateUploadProxyTarget } from '../../../../src/lib/uploadProxyTarget';
 
 export async function POST(request) {
     try {
@@ -11,6 +12,14 @@ export async function POST(request) {
             return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
         }
 
+        const validatedTarget = validateUploadProxyTarget(targetUrl);
+        if (!validatedTarget.ok) {
+            return NextResponse.json(
+                { error: 'Invalid upload target', reason: validatedTarget.reason },
+                { status: 400 }
+            );
+        }
+
         const s3FormData = new FormData();
         for (const [key, value] of formData.entries()) {
             if (key !== 'x-proxy-target-url') {
@@ -18,7 +27,7 @@ export async function POST(request) {
             }
         }
 
-        const s3Response = await fetch(targetUrl, {
+        const s3Response = await fetch(validatedTarget.url, {
             method: 'POST',
             body: s3FormData,
         });

--- a/src/lib/uploadProxyTarget.js
+++ b/src/lib/uploadProxyTarget.js
@@ -1,0 +1,120 @@
+const DEFAULT_S3_REGION_PATTERN = /^[a-z0-9-]+$/;
+
+function normalizeHostname(hostname) {
+    return hostname.toLowerCase().replace(/\.$/, '');
+}
+
+function parseAllowedHosts(env) {
+    return (env.UPLOAD_PROXY_ALLOWED_HOSTS || '')
+        .split(',')
+        .map((host) => normalizeHostname(host.trim()))
+        .filter(Boolean);
+}
+
+function parseIpV4(hostname) {
+    const parts = hostname.split('.');
+    if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) {
+        return null;
+    }
+
+    const octets = parts.map((part) => Number(part));
+    if (octets.some((octet) => octet < 0 || octet > 255)) {
+        return null;
+    }
+
+    return octets;
+}
+
+function isIpLiteral(hostname) {
+    return Boolean(parseIpV4(hostname)) || hostname.includes(':');
+}
+
+function isBlockedIpV4(hostname) {
+    const octets = parseIpV4(hostname);
+    if (!octets) {
+        return false;
+    }
+
+    const [first, second] = octets;
+    return (
+        first === 0 ||
+        first === 10 ||
+        first === 127 ||
+        (first === 169 && second === 254) ||
+        (first === 172 && second >= 16 && second <= 31) ||
+        (first === 192 && second === 168)
+    );
+}
+
+function isBlockedHost(hostname) {
+    const normalized = normalizeHostname(hostname).replace(/^\[|\]$/g, '');
+
+    return (
+        normalized === 'localhost' ||
+        normalized === '::1' ||
+        isIpLiteral(normalized) ||
+        isBlockedIpV4(normalized)
+    );
+}
+
+function isAllowedS3Host(hostname) {
+    // Reject empty labels (leading dot, trailing dot, or consecutive dots).
+    // These never resolve to a real S3 endpoint and must not slip past the
+    // suffix checks below.
+    if (hostname.split('.').some((label) => label === '')) {
+        return false;
+    }
+
+    if (hostname === 's3.amazonaws.com') {
+        return true;
+    }
+
+    if (hostname.endsWith('.s3.amazonaws.com')) {
+        return hostname.length > '.s3.amazonaws.com'.length;
+    }
+
+    const labels = hostname.split('.');
+    if (labels.length === 4 && labels[0] === 's3' && labels[2] === 'amazonaws' && labels[3] === 'com') {
+        return DEFAULT_S3_REGION_PATTERN.test(labels[1]);
+    }
+
+    if (labels.length >= 5 && labels[labels.length - 2] === 'amazonaws' && labels[labels.length - 1] === 'com') {
+        const s3LabelIndex = labels.findIndex((label) => label === 's3');
+        return (
+            s3LabelIndex > 0 &&
+            labels.length - s3LabelIndex === 4 &&
+            DEFAULT_S3_REGION_PATTERN.test(labels[s3LabelIndex + 1])
+        );
+    }
+
+    return false;
+}
+
+export function validateUploadProxyTarget(rawTarget, { env = process.env } = {}) {
+    if (typeof rawTarget !== 'string' || rawTarget.trim() === '') {
+        return { ok: false, reason: 'missing_target' };
+    }
+
+    let url;
+    try {
+        url = new URL(rawTarget);
+    } catch {
+        return { ok: false, reason: 'invalid_url' };
+    }
+
+    if (url.protocol !== 'https:') {
+        return { ok: false, reason: 'unsafe_protocol' };
+    }
+
+    const hostname = normalizeHostname(url.hostname);
+    if (isBlockedHost(hostname)) {
+        return { ok: false, reason: 'host_not_allowed' };
+    }
+
+    const allowedHosts = parseAllowedHosts(env);
+    if (!isAllowedS3Host(hostname) && !allowedHosts.includes(hostname)) {
+        return { ok: false, reason: 'host_not_allowed' };
+    }
+
+    return { ok: true, url: url.toString() };
+}

--- a/tests/uploadProxyTarget.test.js
+++ b/tests/uploadProxyTarget.test.js
@@ -1,0 +1,161 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadValidator() {
+    const { validateUploadProxyTarget } = await import('../src/lib/uploadProxyTarget.js');
+    return validateUploadProxyTarget;
+}
+
+test('validateUploadProxyTarget accepts common S3 upload hosts', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    assert.deepEqual(
+        validateUploadProxyTarget('https://my-bucket.s3.amazonaws.com/'),
+        { ok: true, url: 'https://my-bucket.s3.amazonaws.com/' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('https://my-bucket.s3.us-east-1.amazonaws.com/'),
+        { ok: true, url: 'https://my-bucket.s3.us-east-1.amazonaws.com/' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('https://s3.amazonaws.com/my-bucket'),
+        { ok: true, url: 'https://s3.amazonaws.com/my-bucket' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('https://s3.us-east-1.amazonaws.com/my-bucket'),
+        { ok: true, url: 'https://s3.us-east-1.amazonaws.com/my-bucket' }
+    );
+});
+
+test('validateUploadProxyTarget rejects missing targets', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    assert.deepEqual(validateUploadProxyTarget(), { ok: false, reason: 'missing_target' });
+    assert.deepEqual(validateUploadProxyTarget(''), { ok: false, reason: 'missing_target' });
+    assert.deepEqual(validateUploadProxyTarget('   '), { ok: false, reason: 'missing_target' });
+});
+
+test('validateUploadProxyTarget rejects unsafe protocols', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    assert.deepEqual(
+        validateUploadProxyTarget('http://my-bucket.s3.amazonaws.com/'),
+        { ok: false, reason: 'unsafe_protocol' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('file:///etc/passwd'),
+        { ok: false, reason: 'unsafe_protocol' }
+    );
+});
+
+test('validateUploadProxyTarget rejects invalid URLs', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    assert.deepEqual(
+        validateUploadProxyTarget('not a url'),
+        { ok: false, reason: 'invalid_url' }
+    );
+});
+
+test('validateUploadProxyTarget rejects S3-like hosts with empty labels', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    for (const target of [
+        'https://.s3.amazonaws.com/',
+        'https://..s3.amazonaws.com/',
+        'https://foo..s3.amazonaws.com/',
+    ]) {
+        assert.deepEqual(
+            validateUploadProxyTarget(target),
+            { ok: false, reason: 'host_not_allowed' },
+            target
+        );
+    }
+});
+
+test('validateUploadProxyTarget rejects blocked host literals', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    assert.deepEqual(
+        validateUploadProxyTarget('https://169.254.169.254/latest/meta-data/'),
+        { ok: false, reason: 'host_not_allowed' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('https://localhost:9000/bucket'),
+        { ok: false, reason: 'host_not_allowed' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('https://192.168.1.10/up'),
+        { ok: false, reason: 'host_not_allowed' }
+    );
+});
+
+test('validateUploadProxyTarget honors the allowed hosts env override', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+
+    assert.deepEqual(
+        validateUploadProxyTarget('https://minio.internal.example.com/bucket', {
+            env: { UPLOAD_PROXY_ALLOWED_HOSTS: 'minio.internal.example.com' },
+        }),
+        { ok: true, url: 'https://minio.internal.example.com/bucket' }
+    );
+    assert.deepEqual(
+        validateUploadProxyTarget('https://other.internal.example.com/bucket', {
+            env: { UPLOAD_PROXY_ALLOWED_HOSTS: 'minio.internal.example.com' },
+        }),
+        { ok: false, reason: 'host_not_allowed' }
+    );
+});
+
+test('validateUploadProxyTarget reads process env at call time', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+    const previousAllowedHosts = process.env.UPLOAD_PROXY_ALLOWED_HOSTS;
+
+    try {
+        process.env.UPLOAD_PROXY_ALLOWED_HOSTS = 'uploads.example.com';
+        assert.deepEqual(
+            validateUploadProxyTarget('https://uploads.example.com/bucket'),
+            { ok: true, url: 'https://uploads.example.com/bucket' }
+        );
+
+        process.env.UPLOAD_PROXY_ALLOWED_HOSTS = 'other.example.com';
+        assert.deepEqual(
+            validateUploadProxyTarget('https://uploads.example.com/bucket'),
+            { ok: false, reason: 'host_not_allowed' }
+        );
+    } finally {
+        if (previousAllowedHosts === undefined) {
+            delete process.env.UPLOAD_PROXY_ALLOWED_HOSTS;
+        } else {
+            process.env.UPLOAD_PROXY_ALLOWED_HOSTS = previousAllowedHosts;
+        }
+    }
+});
+
+test('validateUploadProxyTarget blocks unsafe hosts even when env allows them', async () => {
+    const validateUploadProxyTarget = await loadValidator();
+    const previousAllowedHosts = process.env.UPLOAD_PROXY_ALLOWED_HOSTS;
+
+    try {
+        process.env.UPLOAD_PROXY_ALLOWED_HOSTS = 'localhost,192.168.1.10';
+
+        assert.deepEqual(
+            validateUploadProxyTarget('https://localhost:9000/bucket'),
+            { ok: false, reason: 'host_not_allowed' }
+        );
+        assert.deepEqual(
+            validateUploadProxyTarget('https://192.168.1.10/up'),
+            { ok: false, reason: 'host_not_allowed' }
+        );
+        assert.deepEqual(
+            validateUploadProxyTarget('https://8.8.8.8/up'),
+            { ok: false, reason: 'host_not_allowed' }
+        );
+    } finally {
+        if (previousAllowedHosts === undefined) {
+            delete process.env.UPLOAD_PROXY_ALLOWED_HOSTS;
+        } else {
+            process.env.UPLOAD_PROXY_ALLOWED_HOSTS = previousAllowedHosts;
+        }
+    }
+});


### PR DESCRIPTION
## Summary

The `/api/upload-binary` proxy now validates the client-supplied `x-proxy-target-url` before forwarding the request, so a self-hosted instance can no longer be used to relay POSTs to internal hosts or arbitrary endpoints.

## Why this matters

Both `app/api/upload-binary/route.js` and the v1 duplicate read `x-proxy-target-url` from the form data and call `fetch(targetUrl, { method: 'POST', ... })` with no checks. On a publicly reachable instance a crafted multipart POST can point that fetch at `http://169.254.169.254/...`, `http://localhost`, or RFC1918 addresses, turning the proxy into an SSRF gadget. This addresses #162.

## Changes

- Add `src/lib/uploadProxyTarget.js` with a pure `validateUploadProxyTarget(rawTarget, { env })` helper. It requires `https:`, rejects loopback/link-local/private IP literals and `localhost` as a defense-in-depth guard, and only accepts AWS S3 upload hostnames (`s3.amazonaws.com`, `*.s3.amazonaws.com`, `s3.<region>.amazonaws.com`, virtual-hosted region form). Self-hosters can add exact hostnames through `UPLOAD_PROXY_ALLOWED_HOSTS`, but the IP/loopback blocklist still applies. Hostnames with empty labels (leading dot or double dots) are rejected.
- Wire the helper into both routes: an invalid target returns `400` with `{ error: 'Invalid upload target', reason }`, and the fetch uses the validated URL. The existing field-ordering and form-reconstruction logic is unchanged, so legitimate S3 uploads keep working with no client change.
- Add `tests/uploadProxyTarget.test.js`.

## Testing

- `node --test tests/uploadProxyTarget.test.js` -> 9 pass, 0 fail
- `node --test tests/*.test.js` (full suite) -> 26 pass, 0 fail

Fixes #162
