### PR TITLE
fix(local-ai): clarify sd-cli signal/OOM termination errors

### DIFF
--- a/electron/lib/localInference.js
+++ b/electron/lib/localInference.js
@@ -535,7 +535,11 @@ async function generate(params, mainWindow) {
             console.error('[sd-cli] full output:\n' + allOutput);
             if (code !== 0) {
                 const tail = outputLines.filter(l => l.trim()).slice(-20).join('\n');
-                reject(new Error(`sd-cli exited (code ${code}):\n${tail}`));
+                const killed = code === null;
+                const hint = killed
+                    ? 'sd-cli was terminated before finishing (often OOM on Z-Image/SDXL — try a smaller SD 1.5 model or close other apps). '
+                    : '';
+                reject(new Error(`${hint}sd-cli exited (code ${code ?? 'signal'}):\n${tail}`));
                 return;
             }
             if (!fs.existsSync(outPath)) {


### PR DESCRIPTION
When sd-cli exits with a null code (SIGKILL/OOM), surface a hint to try smaller models instead of only showing the debug version string.

Fixes #216