### PR TITLE
feat(i18n): zh-CN locale for web shell and Electron gaps

### DIFF
--- a/components/I18nProvider.jsx
+++ b/components/I18nProvider.jsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { getLang, initLocale, setLang as setLangStore, t as translate } from '../src/lib/i18n.js';
+
+const I18nContext = createContext({
+  lang: 'en',
+  t: translate,
+  setLang: () => {},
+});
+
+export function I18nProvider({ children }) {
+  const [lang, setLangState] = useState('en');
+
+  useEffect(() => {
+    initLocale();
+    setLangState(getLang());
+    document.documentElement.lang = getLang() === 'zh-CN' ? 'zh-CN' : 'en';
+    const onChange = () => {
+      const next = getLang();
+      setLangState(next);
+      document.documentElement.lang = next === 'zh-CN' ? 'zh-CN' : 'en';
+    };
+    window.addEventListener('og_lang_change', onChange);
+    return () => window.removeEventListener('og_lang_change', onChange);
+  }, []);
+
+  const setLang = useCallback((next) => {
+    setLangStore(next, { reload: false });
+    setLangState(getLang());
+  }, []);
+
+  const t = useCallback((key) => translate(key), [lang]);
+
+  const value = useMemo(() => ({ lang, t, setLang }), [lang, t, setLang]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/components/StandaloneShell.js
+++ b/components/StandaloneShell.js
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { ImageStudio, VideoStudio, ClippingStudio, VibeMotionStudio, LipSyncStudio, CinemaStudio, AudioStudio, MarketingStudio, WorkflowStudio, AgentStudio, AppsStudio, getUserBalance } from 'studio';
+import { I18nProvider, useI18n } from './I18nProvider';
+import { initLocale, tabLabel } from '../src/lib/i18n.js';
 
 const DesignAgentStudio = dynamic(() => import('studio').then(mod => mod.DesignAgentStudio), {
   ssr: false,
@@ -12,24 +14,24 @@ const DesignAgentStudio = dynamic(() => import('studio').then(mod => mod.DesignA
 import axios from 'axios';
 import ApiKeyModal from './ApiKeyModal';
 
-const TABS = [
-  { id: 'image',   label: 'Image Studio' },
-  { id: 'video',   label: 'Video Studio' },
-  { id: 'audio',   label: 'Audio Studio' },
-  { id: 'clipping', label: 'AI Clipping' },
-  { id: 'vibe-motion', label: 'Vibe Motion' },
-  { id: 'lipsync', label: 'Lip Sync' },
-  { id: 'cinema',  label: 'Cinema Studio' },
-  { id: 'marketing', label: 'Marketing Studio' },
-  { id: 'workflows', label: 'Workflows' },
-  { id: 'agents', label: 'Agents' },
-  { id: 'design-agent', label: 'Design Agent' },
-  { id: 'apps', label: 'Explore Apps' },
+const TAB_IDS = [
+  'image', 'video', 'audio', 'clipping', 'vibe-motion', 'lipsync', 'cinema',
+  'marketing', 'workflows', 'agents', 'design-agent', 'apps',
 ];
 
 const STORAGE_KEY = 'muapi_key';
 
 export default function StandaloneShell() {
+  return (
+    <I18nProvider>
+      <StandaloneShellInner />
+    </I18nProvider>
+  );
+}
+
+function StandaloneShellInner() {
+  const { t, lang, setLang } = useI18n();
+  const tabs = useMemo(() => TAB_IDS.map((id) => ({ id, label: tabLabel(id) })), [lang, t]);
   const params = useParams();
   const router = useRouter();
   const slug = params?.slug || []; 
@@ -58,7 +60,7 @@ export default function StandaloneShell() {
     if (slug.includes('design-agent')) return 'design-agent';
     if (slug.includes('apps')) return 'apps';
     const firstSegment = slug[0];
-    if (firstSegment && TABS.find(t => t.id === firstSegment)) return firstSegment;
+    if (firstSegment && tabs.find(tab => tab.id === firstSegment)) return firstSegment;
     return 'image';
   };
   
@@ -91,7 +93,7 @@ export default function StandaloneShell() {
         setActiveTab('apps');
     } else {
         const firstSegment = slug[0];
-        if (firstSegment && TABS.find(t => t.id === firstSegment)) {
+        if (firstSegment && tabs.find(tab => tab.id === firstSegment)) {
           setActiveTab(firstSegment);
         }
     }
@@ -136,6 +138,7 @@ export default function StandaloneShell() {
   }, []);
 
   useEffect(() => {
+    initLocale();
     setHasMounted(true);
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
@@ -257,8 +260,8 @@ export default function StandaloneShell() {
               </svg>
             </div>
             <div className="flex flex-col items-center">
-              <span className="text-xl font-bold text-white">Drop your media here</span>
-              <span className="text-sm text-white/40">Images, videos, or audio files</span>
+              <span className="text-xl font-bold text-white">{t('web.dropTitle')}</span>
+              <span className="text-sm text-white/40">{t('web.dropSubtitle')}</span>
             </div>
           </div>
         </div>
@@ -307,7 +310,7 @@ export default function StandaloneShell() {
             <div className="absolute left-0 top-0 bottom-0 w-8 bg-gradient-to-r from-[#030303] to-transparent pointer-events-none z-10 block lg:hidden" />
             
             <nav className="flex items-center gap-4 overflow-x-auto scrollbar-none w-full lg:w-auto h-full px-4 lg:px-0">
-              {TABS.map((tab) => (
+              {tabs.map((tab) => (
                 <button
                   key={tab.id}
                   onClick={() => handleTabChange(tab.id)}
@@ -341,15 +344,23 @@ export default function StandaloneShell() {
             </div>
 
             <button
+              onClick={() => setLang(lang === 'zh-CN' ? 'en' : 'zh-CN')}
+              title={lang === 'zh-CN' ? t('web.switchToEn') : t('web.switchToZh')}
+              className="flex items-center px-3 py-1.5 rounded-md border border-white/10 bg-white/5 text-[13px] font-bold text-white/80 hover:text-white hover:bg-white/10 hover:border-white/20 transition-colors"
+            >
+              {lang === 'zh-CN' ? 'EN' : '中文'}
+            </button>
+
+            <button
               onClick={() => setShowSettings(true)}
-              title="Settings — API key, local models, preferences"
+              title={t('web.settingsTitle')}
               className="flex items-center gap-2 px-3 py-1.5 rounded-md border border-white/10 bg-white/5 text-[13px] font-bold text-white/80 hover:text-white hover:bg-white/10 hover:border-white/20 transition-colors"
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="3" />
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
               </svg>
-              <span>Settings</span>
+              <span>{t('nav.settings')}</span>
             </button>
           </div>
         </header>
@@ -375,15 +386,15 @@ export default function StandaloneShell() {
       {showSettings && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-fade-in-up">
           <div className="bg-[#0a0a0a] border border-white/10 rounded-xl p-8 w-full max-w-sm shadow-2xl">
-            <h2 className="text-white font-bold text-lg mb-2">Settings</h2>
+            <h2 className="text-white font-bold text-lg mb-2">{t('settings.title')}</h2>
             <p className="text-white/40 text-[13px] mb-8">
-              Manage your AI studio preferences and authentication.
+              {t('web.settingsDesc')}
             </p>
             
             <div className="space-y-4 mb-8">
               <div className="bg-white/5 border border-white/[0.03] rounded-md p-4">
                 <label className="block text-xs font-bold text-white/30 mb-2">
-                   Active API Key
+                   {t('web.activeKey')}
                 </label>
                 <div className="text-[13px] font-mono text-white/80">
                   {apiKey.slice(0, 8)}••••••••••••••••
@@ -396,13 +407,13 @@ export default function StandaloneShell() {
                 onClick={handleKeyChange}
                 className="flex-1 h-10 rounded-md bg-red-500/10 text-red-400 hover:bg-red-500/20 text-xs font-semibold transition-all"
               >
-                Change Key
+                {t('web.changeKey')}
               </button>
               <button
                 onClick={() => setShowSettings(false)}
                 className="flex-1 h-10 rounded-md bg-white/5 text-white/80 hover:bg-white/10 text-xs font-semibold transition-all border border-white/5"
               >
-                Close
+                {t('web.close')}
               </button>
             </div>
           </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -66,7 +66,7 @@ export function Header(navigate) {
 
     const settingsBtn = document.createElement('button');
     settingsBtn.className = 'flex items-center gap-2 px-3 py-1.5 rounded-md border border-white/10 bg-white/5 text-[13px] font-bold text-white/80 hover:text-white hover:bg-white/10 hover:border-white/20 transition-colors';
-    settingsBtn.title = 'Settings — API key, local models, preferences';
+    settingsBtn.title = t('web.settingsTitle');
     settingsBtn.innerHTML = `
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="3"/>
@@ -82,9 +82,9 @@ export function Header(navigate) {
     const langBtn = document.createElement('button');
     const currentLang = getLang();
     langBtn.className = 'flex items-center px-3 py-1.5 rounded-md border border-white/10 bg-white/5 text-[13px] font-bold text-white/80 hover:text-white hover:bg-white/10 hover:border-white/20 transition-colors';
-    langBtn.title = currentLang === 'zh' ? 'Switch to English' : '切换为中文';
-    langBtn.textContent = currentLang === 'zh' ? 'EN' : '中文';
-    langBtn.onclick = () => setLang(currentLang === 'zh' ? 'en' : 'zh');
+    langBtn.title = currentLang === 'zh-CN' ? t('web.switchToEn') : t('web.switchToZh');
+    langBtn.textContent = currentLang === 'zh-CN' ? 'EN' : '中文';
+    langBtn.onclick = () => setLang(currentLang === 'zh-CN' ? 'en' : 'zh-CN');
 
     rightPart.appendChild(langBtn);
     rightPart.appendChild(settingsBtn);

--- a/src/components/McpCliStudio.js
+++ b/src/components/McpCliStudio.js
@@ -1,3 +1,5 @@
+import { t } from '../lib/i18n.js';
+
 export function McpCliStudio() {
     const container = document.createElement('div');
     container.className = 'w-full h-full overflow-y-auto bg-app-bg text-white';
@@ -11,13 +13,11 @@ export function McpCliStudio() {
     hero.className = 'flex flex-col items-center text-center gap-4';
     hero.innerHTML = `
         <div class="px-3 py-1 rounded-full border border-white/10 bg-white/5 text-[11px] font-bold uppercase tracking-widest text-secondary">
-            For developers & AI agents
+            ${t('mcp.tagline')}
         </div>
-        <h1 class="text-4xl md:text-5xl font-bold tracking-tight">MCP &amp; CLI</h1>
+        <h1 class="text-4xl md:text-5xl font-bold tracking-tight">${t('mcp.title')}</h1>
         <p class="text-secondary text-base md:text-lg max-w-2xl">
-            Use Open Generative AI from your terminal, your IDE, or any MCP-compatible
-            assistant. Generate cinematic images, videos, and audio across 100+ models —
-            without leaving your workflow.
+            ${t('mcp.subtitle')}
         </p>
     `;
     inner.appendChild(hero);
@@ -27,7 +27,7 @@ export function McpCliStudio() {
     quick.className = 'glass-panel rounded-2xl p-6 md:p-8 flex flex-col gap-4';
     quick.innerHTML = `
         <div class="flex items-center gap-2">
-            <span class="text-[11px] font-bold uppercase tracking-widest text-secondary">Quick start</span>
+            <span class="text-[11px] font-bold uppercase tracking-widest text-secondary">${t('mcp.quickStart')}</span>
             <div class="flex-1 h-px bg-white/5"></div>
         </div>
         <div class="grid md:grid-cols-3 gap-4">

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,12 +1,51 @@
 const LANG_KEY = 'og_lang';
 
-export function getLang() {
-    return localStorage.getItem(LANG_KEY) || 'en';
+/** Normalize legacy `zh` and browser locales to BCP-47 zh-CN. */
+export function normalizeLang(raw) {
+    if (!raw) return 'en';
+    const lower = String(raw).toLowerCase();
+    if (lower === 'zh' || lower.startsWith('zh-') || lower.startsWith('zh_')) return 'zh-CN';
+    return lower === 'zh-cn' ? 'zh-CN' : 'en';
 }
 
-export function setLang(lang) {
+/** Detect browser locale on first visit; migrates stored `zh` → `zh-CN`. */
+export function initLocale() {
+    if (typeof localStorage === 'undefined') return 'en';
+    const stored = localStorage.getItem(LANG_KEY);
+    if (stored) {
+        const normalized = normalizeLang(stored);
+        if (normalized !== stored) localStorage.setItem(LANG_KEY, normalized);
+        return normalized;
+    }
+    const detected = typeof navigator !== 'undefined' ? navigator.language : 'en';
+    const lang = normalizeLang(detected);
     localStorage.setItem(LANG_KEY, lang);
-    location.reload();
+    return lang;
+}
+
+export function getLang() {
+    if (typeof localStorage === 'undefined') return 'en';
+    const stored = localStorage.getItem(LANG_KEY);
+    if (!stored) return initLocale();
+    const normalized = normalizeLang(stored);
+    if (normalized !== stored) localStorage.setItem(LANG_KEY, normalized);
+    return normalized;
+}
+
+export function setLang(lang, { reload = true } = {}) {
+    const normalized = normalizeLang(lang);
+    localStorage.setItem(LANG_KEY, normalized);
+    if (reload && typeof location !== 'undefined') {
+        location.reload();
+    } else if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('og_lang_change', { detail: normalized }));
+    }
+}
+
+function dictFor(lang) {
+    const key = normalizeLang(lang);
+    if (key === 'zh-CN') return translations['zh-CN'] || translations.zh;
+    return translations.en;
 }
 
 const translations = {
@@ -199,7 +238,31 @@ const translations = {
         'localModels.probing': 'Probing...',
         'localModels.errorLoading': 'Error loading models: ',
         'localModels.deleteConfirm': (name) => `Delete "${name}"? You'll need to re-download it to use it again.`,
+
+        // Web shell (Next.js)
+        'web.tab.audio': 'Audio Studio',
+        'web.tab.clipping': 'AI Clipping',
+        'web.tab.vibeMotion': 'Vibe Motion',
+        'web.tab.marketing': 'Marketing Studio',
+        'web.tab.designAgent': 'Design Agent',
+        'web.tab.apps': 'Explore Apps',
+        'web.dropTitle': 'Drop your media here',
+        'web.dropSubtitle': 'Images, videos, or audio files',
+        'web.settingsDesc': 'Manage your AI studio preferences and authentication.',
+        'web.activeKey': 'Active API Key',
+        'web.changeKey': 'Change Key',
+        'web.close': 'Close',
+        'web.settingsTitle': 'Settings — API key, local models, preferences',
+        'web.switchToEn': 'Switch to English',
+        'web.switchToZh': '切换为中文',
+
+        // MCP & CLI page
+        'mcp.tagline': 'For developers & AI agents',
+        'mcp.title': 'MCP & CLI',
+        'mcp.subtitle': 'Use Open Generative AI from your terminal, your IDE, or any MCP-compatible assistant. Generate cinematic images, videos, and audio across 100+ models — without leaving your workflow.',
+        'mcp.quickStart': 'Quick start',
     },
+    'zh-CN': null,
     zh: {
         // Navigation
         'nav.image': '图像',
@@ -389,19 +452,64 @@ const translations = {
         'localModels.probing': '探测中...',
         'localModels.errorLoading': '加载模型时出错：',
         'localModels.deleteConfirm': (name) => `删除"${name}"？您需要重新下载才能再次使用。`,
+
+        // Web shell (Next.js)
+        'web.tab.audio': '音频工作室',
+        'web.tab.clipping': 'AI 剪辑',
+        'web.tab.vibeMotion': 'Vibe Motion',
+        'web.tab.marketing': '营销工作室',
+        'web.tab.designAgent': '设计智能体',
+        'web.tab.apps': '探索应用',
+        'web.dropTitle': '将媒体文件拖放到此处',
+        'web.dropSubtitle': '图像、视频或音频文件',
+        'web.settingsDesc': '管理 AI 工作室偏好设置和身份验证。',
+        'web.activeKey': '当前 API 密钥',
+        'web.changeKey': '更换密钥',
+        'web.close': '关闭',
+        'web.settingsTitle': '设置 — API 密钥、本地模型、偏好',
+        'web.switchToEn': 'Switch to English',
+        'web.switchToZh': '切换为中文',
+
+        // MCP & CLI page
+        'mcp.tagline': '面向开发者与 AI 智能体',
+        'mcp.title': 'MCP & CLI',
+        'mcp.subtitle': '在终端、IDE 或任何兼容 MCP 的助手中使用 Open Generative AI。跨 100+ 模型生成电影级图像、视频和音频 — 无需离开您的工作流。',
+        'mcp.quickStart': '快速开始',
     },
 };
 
+translations['zh-CN'] = translations.zh;
+
+const TAB_LABEL_KEYS = {
+    image: 'image.title',
+    video: 'video.title',
+    audio: 'web.tab.audio',
+    clipping: 'web.tab.clipping',
+    'vibe-motion': 'web.tab.vibeMotion',
+    lipsync: 'lipsync.title',
+    cinema: 'cinema.tagline',
+    marketing: 'web.tab.marketing',
+    workflows: 'workflows.title',
+    agents: 'agents.title',
+    'design-agent': 'web.tab.designAgent',
+    apps: 'web.tab.apps',
+};
+
+export function tabLabel(tabId) {
+    const key = TAB_LABEL_KEYS[tabId];
+    return key ? t(key) : tabId;
+}
+
 export function t(key) {
     const lang = getLang();
-    const dict = translations[lang] || translations.en;
+    const dict = dictFor(lang);
     const val = dict[key] !== undefined ? dict[key] : (translations.en[key] !== undefined ? translations.en[key] : key);
     return typeof val === 'function' ? val : val;
 }
 
 export function tf(key, ...args) {
     const lang = getLang();
-    const dict = translations[lang] || translations.en;
+    const dict = dictFor(lang);
     const val = dict[key] !== undefined ? dict[key] : (translations.en[key] !== undefined ? translations.en[key] : key);
     return typeof val === 'function' ? val(...args) : val;
 }


### PR DESCRIPTION
Normalize og_lang to zh-CN, detect browser locale on first visit, wire Next.js StandaloneShell tabs/settings with I18nProvider, and translate MCP & CLI hero copy.

Fixes Anil-matcha/Open-Generative-AI#224