### PR TITLE
Align AI Clipping empty state layout

### DIFF
--- a/packages/studio/src/components/ClippingStudio.jsx
+++ b/packages/studio/src/components/ClippingStudio.jsx
@@ -434,7 +434,7 @@ export default function ClippingStudio({
 
         {/* 1. Empty State (No history, no result active) */}
         {!result && history.length === 0 && (
-          <div className="flex-grow flex flex-col items-center justify-center animate-fade-in-up transition-all duration-700 min-h-[55vh]">
+          <div className="flex flex-col items-center justify-center h-full animate-fade-in-up transition-all duration-700 min-h-[50vh]">
             {/* Overlapping floating cards */}
             <div className="flex items-center justify-center gap-1.5 md:gap-3 mb-10 select-none scale-90 sm:scale-100">
               <div className="w-18 h-22 sm:w-24 sm:h-28 rounded-2xl border border-white/10 shadow-2xl -rotate-[12deg] transform hover:rotate-0 hover:scale-110 hover:z-20 transition-all duration-300 overflow-hidden bg-white/[0.01] flex-shrink-0">


### PR DESCRIPTION
## Summary
- Align the AI Clipping empty state vertically with the other video studio screens.
- Reuse the existing `h-full` and `min-h-[50vh]` layout pattern.
- Remove the Clipping-specific `flex-grow` and `min-h-[55vh]` override.

## Verification
- `npm run build:studio`
- `npm run build`
- Compared AI Clipping and Vibe Motion at 1440×900; both empty-state content blocks now share the same vertical bounds and center.