### PR TITLE
fix(upload-binary): prevent SSRF via x-proxy-target-url allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Generative AI — Unrestricted Open-Source Alternative to AI Video Platforms
+# Open Generative AI — Open-Source Alternative to AI Video Platforms
 
 [![Powered by MuAPI](https://img.shields.io/badge/Powered%20by-MuAPI-6366f1?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0tMSAxNHYtNGgtMnYtMmg0djZoLTJ6bTAtOFY2aDJ2MmgtMnoiLz48L3N2Zz4=)](https://muapi.ai?utm_source=github&utm_medium=badge&utm_campaign=open-generative-ai)
 
@@ -6,6 +6,8 @@
 > **The free, open-source alternative to AI Video Platforms.** Generate AI images and videos using 200+ state-of-the-art models — no content filters, no closed ecosystem, no subscription fees.
 
 **Community:** Join [Reddit](https://www.reddit.com/r/muapi) & [Discord](https://discord.gg/QhTrNRU4r3) for discussions and support
+
+> **Latest Gemini Omni model from Google best prompts and resources:** [Gemini Omni Resources](https://github.com/Anil-matcha/Awesome-Gemini-Omni-API-Prompts)
 
 > 🤖 **Automate media generations with AI coding agents:** [Generative-Media-Skills](https://github.com/SamurAIGPT/Generative-Media-Skills) — a library of skills that let agents like **Claude Code**, **Codex**, and other coding assistants drive 200+ image/video models end-to-end (prompt → generate → edit → stitch) directly from your terminal. Perfect for building automated media pipelines without touching a UI.
 

--- a/app/api/upload-binary/route.js
+++ b/app/api/upload-binary/route.js
@@ -1,5 +1,30 @@
 import { NextResponse } from 'next/server';
 
+// Hostnames (or suffixes) permitted as upload targets for the S3 proxy.
+// The upstream (MuAPI) returns presigned URLs on AWS S3 / S3-compatible storage.
+// We restrict the proxy to those hosts to prevent SSRF via the
+// user-controllable `x-proxy-target-url` form field.
+const ALLOWED_HOST_SUFFIXES = [
+    '.amazonaws.com',
+    '.s3.amazonaws.com',
+    '.cloudfront.net',
+    '.muapi.ai',
+];
+
+function isAllowedTarget(rawUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname.toLowerCase();
+    return ALLOWED_HOST_SUFFIXES.some(
+        (suffix) => host === suffix.replace(/^\./, '') || host.endsWith(suffix)
+    );
+}
+
 export async function POST(request) {
     try {
         const formData = await request.formData();
@@ -9,6 +34,10 @@ export async function POST(request) {
         
         if (!targetUrl) {
             return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
+        }
+
+        if (typeof targetUrl !== 'string' || !isAllowedTarget(targetUrl)) {
+            return NextResponse.json({ error: 'Invalid proxy target URL' }, { status: 400 });
         }
 
         // Reconstruct the FormData for S3 (excluding our internal proxy marker)

--- a/app/api/v1/upload-binary/route.js
+++ b/app/api/v1/upload-binary/route.js
@@ -1,5 +1,30 @@
 import { NextResponse } from 'next/server';
 
+// Hostnames (or suffixes) permitted as upload targets for the S3 proxy.
+// The upstream returns presigned URLs on AWS S3 / S3-compatible storage.
+// We restrict the proxy to those hosts to prevent SSRF via the
+// user-controllable `x-proxy-target-url` form field.
+const ALLOWED_HOST_SUFFIXES = [
+    '.amazonaws.com',
+    '.s3.amazonaws.com',
+    '.cloudfront.net',
+    '.muapi.ai',
+];
+
+function isAllowedTarget(rawUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname.toLowerCase();
+    return ALLOWED_HOST_SUFFIXES.some(
+        (suffix) => host === suffix.replace(/^\./, '') || host.endsWith(suffix)
+    );
+}
+
 export async function POST(request) {
     try {
         const formData = await request.formData();
@@ -9,6 +34,10 @@ export async function POST(request) {
         
         if (!targetUrl) {
             return NextResponse.json({ error: 'Missing proxy target URL' }, { status: 400 });
+        }
+
+        if (typeof targetUrl !== 'string' || !isAllowedTarget(targetUrl)) {
+            return NextResponse.json({ error: 'Invalid proxy target URL' }, { status: 400 });
         }
 
         const s3FormData = new FormData();


### PR DESCRIPTION
## Summary

The `/api/upload-binary` and `/api/v1/upload-binary` routes act as a server-side proxy for S3 uploads. The destination is taken directly from the `x-proxy-target-url` field on the incoming multipart form and passed to `fetch()` without any validation. That makes both endpoints a Server-Side Request Forgery (SSRF) sink (CWE-918): an attacker who can reach the Next.js server can coerce it into issuing arbitrary outbound requests — including to internal services or cloud metadata endpoints such as `http://169.254.169.254/latest/meta-data/`.

The routes have no auth gate — there is no `middleware.ts` at the project root and no per-route auth check — so any client that can reach the app can trigger the proxy.

- **Affected files:** `app/api/upload-binary/route.js`, `app/api/v1/upload-binary/route.js`
- **Sink:** `fetch(targetUrl, { method: 'POST', body: s3FormData })` where `targetUrl = formData.get('x-proxy-target-url')`
- **CWE:** 918 (SSRF)

## Fix

Both routes now validate `x-proxy-target-url` against a small allowlist before calling `fetch()`:

- URL is parsed with the WHATWG `URL` constructor (so userinfo tricks like `https://s3.amazonaws.com@169.254.169.254/` don't smuggle a different host past the check).
- Protocol must be `https:` (blocks `file:`, `gopher:`, `http:` to plaintext internal services).
- Hostname must exactly match, or be a subdomain of, one of: `.amazonaws.com`, `.s3.amazonaws.com`, `.cloudfront.net`, `.muapi.ai`. The check is suffix-anchored on `.<suffix>` so lookalikes like `amazonaws.com.evil.com` don't match.
- IP literals never match a DNS suffix, so `169.254.169.254`, `127.0.0.1`, decimal/hex/octal encodings, and `[::1]` are all rejected.

Rejected requests return `400 Invalid proxy target URL`. Legitimate presigned URLs returned by MuAPI (which point at AWS S3 / CloudFront) continue to work unchanged.

## Proof of concept

Before the fix, against a local dev server:

```bash
# Force the server to hit the AWS instance metadata service
curl -X POST http://localhost:3000/api/upload-binary \
  -F "file=@/tmp/x" \
  -F "x-proxy-target-url=http://169.254.169.254/latest/meta-data/"
# → server issues outbound request to 169.254.169.254

# Reach an internal admin service on the host
curl -X POST http://localhost:3000/api/upload-binary \
  -F "file=@/tmp/x" \
  -F "x-proxy-target-url=http://127.0.0.1:6379/"
```

After the fix, both requests return `{"error":"Invalid proxy target URL"}` with HTTP 400. Presigned URLs of the form `https://<bucket>.s3.amazonaws.com/...` continue to be proxied normally.

## What was tested

The allowlist logic was exercised against the following cases; all bypass attempts are rejected and all legitimate targets are accepted:

- Rejected: `http://169.254.169.254/latest/meta-data/`, `http://127.0.0.1:6379/`, `http://[::1]/`, `http://2130706433/`, `http://0x7f000001/`, `file:///etc/passwd`, `gopher://127.0.0.1:6379/_INFO`, `https://amazonaws.com.evil.com/`, `https://evil.com/amazonaws.com`, `https://s3.amazonaws.com@169.254.169.254/`, `not-a-url`, empty string.
- Accepted: `https://my-bucket.s3.amazonaws.com/key`, `https://d123.cloudfront.net/asset`, `https://api.muapi.ai/upload`.

## Adversarial review

Before submitting we tried to disprove the finding. The routes are part of a self-hostable app, so we asked whether an attacker realistically reaches them and whether existing controls block exploitation. They don't: there is no auth middleware, no host/CORS restriction on the route, and the `fetch()` call trusts the raw form value. Anyone who can reach the Next.js server on the network — including LAN peers on a developer's machine and anyone hitting a publicly-exposed deployment — can drive the proxy. AWS IMDSv2 mitigates the metadata angle on modern EC2, but IMDSv1 is still common on self-hosted setups and internal-service pivots (Redis, Docker socket over TCP, admin panels on loopback) don't depend on cloud metadata at all. The fix is a positive allowlist rather than a denylist, which avoids the usual round of bypasses (encoded IPs, IPv6, DNS rebinding on the hostname string, userinfo `@` confusion).