### PR TITLE
fix: reject API keys invalid in HTTP headers

### DIFF
--- a/components/ApiKeyModal.js
+++ b/components/ApiKeyModal.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { validateApiKey } from './apiKeyValidation.mjs';
 
 export default function ApiKeyModal({ onSave, onClose, overlay = false, title, subtitle }) {
   const [key, setKey] = useState('');
@@ -8,9 +9,9 @@ export default function ApiKeyModal({ onSave, onClose, overlay = false, title, s
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    const trimmed = key.trim();
-    if (!trimmed) { setError('Please enter your API key'); return; }
-    onSave(trimmed);
+    const result = validateApiKey(key);
+    if (result.error) { setError(result.error); return; }
+    onSave(result.value);
   };
 
   const wrapperClass = overlay

--- a/components/apiKeyValidation.mjs
+++ b/components/apiKeyValidation.mjs
@@ -1,0 +1,15 @@
+export function validateApiKey(value) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return { error: 'Please enter your API key' };
+  }
+
+  try {
+    new Headers({ 'x-api-key': trimmed });
+  } catch {
+    return { error: 'API key contains characters that cannot be sent in an HTTP header' };
+  }
+
+  return { value: trimmed };
+}

--- a/tests/apiKeyValidation.test.mjs
+++ b/tests/apiKeyValidation.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validateApiKey } from '../components/apiKeyValidation.mjs';
+
+test('accepts and trims an ASCII API key', () => {
+  assert.deepEqual(validateApiKey('  valid-api-key_123  '), {
+    value: 'valid-api-key_123',
+  });
+});
+
+test('rejects an empty API key', () => {
+  assert.deepEqual(validateApiKey('   '), {
+    error: 'Please enter your API key',
+  });
+});
+
+test('rejects characters that cannot be encoded in an HTTP header', () => {
+  for (const value of ['key\u200b', 'key\ud83d\ude00']) {
+    assert.deepEqual(validateApiKey(value), {
+      error: 'API key contains characters that cannot be sent in an HTTP header',
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- validate API keys against HTTP header encoding rules before saving them
- show an inline error for pasted keys containing unsupported characters
- cover trimming, empty input, zero-width characters, and emoji with unit tests

## Why
A malformed pasted key currently reaches `fetch` or `XMLHttpRequest` and throws before any network request is sent. Validating at entry makes the error actionable and prevents the invalid value from being persisted.

Closes #301

## Testing
- Ran: `node --test tests/apiKeyValidation.test.mjs`
- Ran: `npm run build:packages`
- Ran: `npm run build`