### PR TITLE
fix(studio): resolve video tool workflow bugs

### DIFF
--- a/packages/studio/src/components/VideoStudio.jsx
+++ b/packages/studio/src/components/VideoStudio.jsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import { generateVideo, generateI2V, processV2V, uploadFile } from "../muapi.js";
 import { formatErrorMessage } from "../utils/formatError.js";
 import { scopedPersistKey, migrateLegacyPersistKey } from "../persistKey.js";
+import {
+  getCompatibleContinuationSources,
+  getContinuationConfig,
+  getDefaultVideoToolOptions,
+  getVideoToolOptionDefinitions,
+  getVideoToolPresentation,
+  resolveVideoUploadTransition,
+} from "../videoToolCapabilities.js";
 import DrawModal from "./DrawModal.jsx";
 import MobileGenerationActions, {
   GenerationCopyButtons,
@@ -443,6 +451,80 @@ function ModelDropdown({ selectedModel, onSelect, onClose }) {
   );
 }
 
+function VideoToolOptionControls({
+  definitions,
+  values,
+  onChange,
+  openDropdown,
+  setOpenDropdown,
+  toggleDropdown,
+}) {
+  return definitions.map((definition) => {
+    const value = values[definition.key];
+
+    if (definition.type === "boolean") {
+      return (
+        <button
+          key={definition.key}
+          type="button"
+          onClick={() => onChange(definition.key, !value)}
+          className={promptControlClassName({ active: Boolean(value) })}
+          title={definition.title}
+        >
+          <PromptQualityIcon />
+          <span className={PROMPT_CONTROL_LABEL_CLASS}>
+            {definition.title}: {value ? "On" : "Off"}
+          </span>
+        </button>
+      );
+    }
+
+    const dropdownId = `video-option:${definition.key}`;
+    const valueLabel =
+      definition.key === "upscale_factor" ? `${value}×` : String(value ?? "");
+
+    return (
+      <div key={definition.key} className="relative">
+        <button
+          type="button"
+          onClick={toggleDropdown(dropdownId)}
+          className={promptControlClassName({
+            active: openDropdown === dropdownId,
+          })}
+          title={definition.title}
+        >
+          <PromptQualityIcon />
+          <span className={PROMPT_CONTROL_LABEL_CLASS}>{valueLabel}</span>
+          <PromptChevronIcon />
+        </button>
+        {openDropdown === dropdownId && (
+          <PromptPopover
+            onClick={(event) => event.stopPropagation()}
+            className="min-w-[240px] max-h-[320px]"
+          >
+            <PromptPopoverHeader>{definition.title}</PromptPopoverHeader>
+            <PromptMenuList>
+              {(definition.enum || []).map((option) => (
+                <PromptMenuItem
+                  key={option}
+                  selected={value === option}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onChange(definition.key, option);
+                    setOpenDropdown(null);
+                  }}
+                >
+                  {definition.key === "upscale_factor" ? `${option}×` : option}
+                </PromptMenuItem>
+              ))}
+            </PromptMenuList>
+          </PromptPopover>
+        )}
+      </div>
+    );
+  });
+}
+
 // ── Control button ────────────────────────────────────────────────────────────
 
 // ── Dropdown panel ─────────────────────────────────────────────────────────────
@@ -489,6 +571,8 @@ export default function VideoStudio({
   );
   const [selectedMode, setSelectedMode] = useState("");
   const [selectedEffect, setSelectedEffect] = useState("");
+  const [videoToolOptions, setVideoToolOptions] = useState({});
+  const [continuationSourceIds, setContinuationSourceIds] = useState({});
 
   // ── upload progress ──
   const [imageProgress, setImageProgress] = useState(0);
@@ -518,11 +602,8 @@ export default function VideoStudio({
   const [generateError, setGenerateError] = useState(null);
   const [fullscreenUrl, setFullscreenUrl] = useState(null);
   const [canvasUrl, setCanvasUrl] = useState(null);
-  const [canvasModel, setCanvasModel] = useState(null);
   const [showCanvas, setShowCanvas] = useState(false);
   const [isDrawModalOpen, setIsDrawModalOpen] = useState(false);
-  const [lastGenerationId, setLastGenerationId] = useState(null);
-  const [lastGenerationModel, setLastGenerationModel] = useState(null);
 
   // ── history ──
   const [localHistory, setLocalHistory] = useState([]);
@@ -533,7 +614,6 @@ export default function VideoStudio({
 
   // ── prompt ──
   const [prompt, setPrompt] = useState("");
-  const [promptDisabled, setPromptDisabled] = useState(false);
 
   // ── refs ──
   const containerRef = useRef(null);
@@ -592,6 +672,37 @@ export default function VideoStudio({
     [getCurrentModels, selectedModel],
   );
 
+  const currentModelObj = getCurrentModel();
+  const currentToolPresentation = useMemo(
+    () => getVideoToolPresentation(currentModelObj),
+    [currentModelObj],
+  );
+  const continuationConfig = useMemo(
+    () => getContinuationConfig(currentModelObj),
+    [currentModelObj],
+  );
+  const compatibleContinuationSources = useMemo(
+    () => getCompatibleContinuationSources(currentModelObj, history),
+    [currentModelObj, history],
+  );
+  const selectedContinuationSource = useMemo(() => {
+    if (!continuationConfig) return null;
+    const selectedRequestId = continuationSourceIds[continuationConfig.family];
+    return (
+      compatibleContinuationSources.find(
+        (entry) => entry.requestId === selectedRequestId,
+      ) || compatibleContinuationSources[0] || null
+    );
+  }, [
+    compatibleContinuationSources,
+    continuationConfig,
+    continuationSourceIds,
+  ]);
+  const videoToolOptionDefinitions = useMemo(
+    () => getVideoToolOptionDefinitions(currentModelObj),
+    [currentModelObj],
+  );
+
   const isMotionControlSelection = useCallback(
     (modelId, isV2v) => {
       if (!isV2v) return false;
@@ -620,7 +731,9 @@ export default function VideoStudio({
       const ars = isImageMode
         ? getAspectRatiosForI2VModel(modelId)
         : getAspectRatiosForVideoModel(modelId);
-      if (ars.length > 0) {
+      const hasApplicableAspectRatio =
+        !model?.requiresRequestId || Boolean(model.inputs?.aspect_ratio);
+      if (ars.length > 0 && hasApplicableAspectRatio) {
         setSelectedAr(ars[0]);
         setShowAr(true);
       } else {
@@ -693,6 +806,17 @@ export default function VideoStudio({
         if (data.selectedQuality) setSelectedQuality(data.selectedQuality);
         if (data.selectedMode) setSelectedMode(data.selectedMode);
         if (data.selectedEffect) setSelectedEffect(data.selectedEffect);
+        if (data.videoToolOptions) {
+          setVideoToolOptions(data.videoToolOptions);
+        } else if (data.selectedModel) {
+          const restoredModel = [...t2vModels, ...i2vModels, ...v2vModels].find(
+            (model) => model.id === data.selectedModel,
+          );
+          setVideoToolOptions(getDefaultVideoToolOptions(restoredModel));
+        }
+        if (data.continuationSourceIds) {
+          setContinuationSourceIds(data.continuationSourceIds);
+        }
         if (data.uploadedImageUrl) setUploadedImageUrl(data.uploadedImageUrl);
         if (data.uploadedImageUrls) {
           setUploadedImageUrls(data.uploadedImageUrls);
@@ -733,6 +857,8 @@ export default function VideoStudio({
           selectedQuality,
           selectedMode,
           selectedEffect,
+          videoToolOptions,
+          continuationSourceIds,
           uploadedImageUrl,
           uploadedImageUrls,
           uploadedVideoUrl,
@@ -757,6 +883,8 @@ export default function VideoStudio({
     selectedQuality,
     selectedMode,
     selectedEffect,
+    videoToolOptions,
+    continuationSourceIds,
     uploadedImageUrl,
     uploadedImageUrls,
     uploadedVideoUrl,
@@ -776,7 +904,6 @@ export default function VideoStudio({
       // Motion-control models use the image alongside the uploaded video.
       if (isMotionControlSelection(selectedModel, v2vMode)) {
         setUploadedImageUrls([url]);
-        setPromptDisabled(false);
         return;
       }
 
@@ -789,7 +916,6 @@ export default function VideoStudio({
           if (previousUrls.includes(url)) return previousUrls;
           return [...previousUrls, url].slice(0, maxImages);
         });
-        setPromptDisabled(false);
         return;
       }
 
@@ -822,7 +948,6 @@ export default function VideoStudio({
       } else {
         setUploadedImageUrls([url]);
       }
-      setPromptDisabled(false);
     },
     [
       applyControlsForModel,
@@ -863,6 +988,45 @@ export default function VideoStudio({
     [apiKey, applyImageReferenceUrl],
   );
 
+  const applyUploadedVideo = useCallback(
+    (url, name) => {
+      const mode = v2vMode ? "v2v" : imageMode ? "i2v" : "t2v";
+      const transition = resolveVideoUploadTransition({
+        mode,
+        currentModel: getCurrentModel(),
+        defaultModel: v2vModels[0],
+      });
+
+      setUploadedVideoUrl(url);
+      setUploadedVideoName(name);
+
+      if (transition.clearImage) {
+        setUploadedImageUrl(null);
+        setUploadedImageUrls([]);
+        setUploadedEndImageUrl(null);
+      }
+      if (transition.clearPrompt) setPrompt("");
+
+      if (transition.mode === "v2v" && transition.model) {
+        setImageMode(false);
+        setV2vMode(true);
+        if (transition.model.id !== selectedModel) {
+          setSelectedModel(transition.model.id);
+          setSelectedModelName(transition.model.name);
+          setVideoToolOptions(getDefaultVideoToolOptions(transition.model));
+          applyControlsForModel(transition.model.id, false, true);
+        }
+      }
+    },
+    [
+      applyControlsForModel,
+      getCurrentModel,
+      imageMode,
+      selectedModel,
+      v2vMode,
+    ],
+  );
+
   const processDroppedVideo = useCallback(
     async (file) => {
       if (file.size > 50 * 1024 * 1024) {
@@ -873,19 +1037,7 @@ export default function VideoStudio({
       setVideoProgress(0);
       try {
         const url = await uploadFile(apiKey, file, setVideoProgress);
-        setUploadedVideoUrl(url);
-        setUploadedVideoName(file.name);
-        if (imageMode) {
-          setUploadedImageUrl(null);
-          setImageMode(false);
-        }
-        setV2vMode(true);
-        const firstV2V = v2vModels[0];
-        setSelectedModel(firstV2V.id);
-        setSelectedModelName(firstV2V.name);
-        applyControlsForModel(firstV2V.id, false, true);
-        setPrompt("");
-        setPromptDisabled(true);
+        applyUploadedVideo(url, file.name);
       } catch (err) {
         alert(`Video upload failed: ${err.message}`);
       } finally {
@@ -893,7 +1045,7 @@ export default function VideoStudio({
         setVideoProgress(0);
       }
     },
-    [apiKey, applyControlsForModel, imageMode],
+    [apiKey, applyUploadedVideo],
   );
 
   // ── Handle Dropped Files ────────────────────────────────────────────────
@@ -958,7 +1110,6 @@ export default function VideoStudio({
     setSelectedModel(first.id);
     setSelectedModelName(first.name);
     applyControlsForModel(first.id, false, false);
-    setPromptDisabled(false);
   };
 
   const removeImageAtIndex = (idx) => {
@@ -973,7 +1124,6 @@ export default function VideoStudio({
       setSelectedModel(first.id);
       setSelectedModelName(first.name);
       applyControlsForModel(first.id, false, false);
-      setPromptDisabled(false);
     } else {
       setUploadedImageUrl(nextUrls[0]);
     }
@@ -1019,33 +1169,7 @@ export default function VideoStudio({
       const url = await uploadFile(apiKey, file, (pct) => {
         setVideoProgress(pct);
       });
-      setUploadedVideoUrl(url);
-      setUploadedVideoName(file.name);
-
-      if (isMotionControlSelection(selectedModel, v2vMode)) {
-        // Already in motion-control mode — keep model and image, allow prompt
-        setPromptDisabled(false);
-      } else {
-        // Model-native video reference (e.g. Seedance 2.0 Extend with inputs.video_files):
-        // keep the current model & mode; just store the video URL as a reference
-        const currentT2VOrExtend = t2vModels.find((m) => m.id === selectedModel);
-        if (currentT2VOrExtend?.inputs?.video_files) {
-          setPromptDisabled(false);
-        } else {
-          // Default v2v flow (e.g. watermark remover) — auto-pick the first v2v model
-          if (imageMode) {
-            setUploadedImageUrl(null);
-            setImageMode(false);
-          }
-          setV2vMode(true);
-          const firstV2V = v2vModels[0];
-          setSelectedModel(firstV2V.id);
-          setSelectedModelName(firstV2V.name);
-          applyControlsForModel(firstV2V.id, false, true);
-          setPrompt("");
-          setPromptDisabled(true);
-        }
-      }
+      applyUploadedVideo(url, file.name);
     } catch (err) {
       console.error("[VideoStudio] Video upload failed:", err);
       alert(`Video upload failed: ${err.message}`);
@@ -1059,12 +1183,6 @@ export default function VideoStudio({
   const clearVideoUpload = () => {
     setUploadedVideoUrl(null);
     setUploadedVideoName(null);
-    setV2vMode(false);
-    const first = t2vModels[0];
-    setSelectedModel(first.id);
-    setSelectedModelName(first.name);
-    applyControlsForModel(first.id, false, false);
-    setPromptDisabled(false);
   };
 
   // ── model selection from dropdown ─────────────────────────────────────────
@@ -1081,20 +1199,13 @@ export default function VideoStudio({
         }
         setSelectedModel(m.id);
         setSelectedModelName(m.name);
+        setVideoToolOptions(getDefaultVideoToolOptions(m));
         applyControlsForModel(m.id, false, true);
-        if (isMC) {
-          // Motion-control: prompt is editable, video+image are needed
-          setPromptDisabled(false);
-        } else {
-          setPrompt("");
-          setPromptDisabled(true);
-        }
       } else {
         if (v2vMode) {
           setV2vMode(false);
           setUploadedVideoUrl(null);
           setUploadedVideoName(null);
-          setPromptDisabled(false);
         }
         const nextImageMode = category === "i2v";
         if (!nextImageMode && imageMode) {
@@ -1105,6 +1216,7 @@ export default function VideoStudio({
         setImageMode(nextImageMode);
         setSelectedModel(m.id);
         setSelectedModelName(m.name);
+        setVideoToolOptions(getDefaultVideoToolOptions(m));
         applyControlsForModel(m.id, nextImageMode, false);
       }
     },
@@ -1118,16 +1230,14 @@ export default function VideoStudio({
   }, []);
 
   // ── show result in canvas ─────────────────────────────────────────────────
-  const showVideoInCanvas = useCallback((url, model) => {
+  const showVideoInCanvas = useCallback((url) => {
     setCanvasUrl(url);
-    setCanvasModel(model);
     setShowCanvas(true);
   }, []);
 
   // ── generate ──────────────────────────────────────────────────────────────
   const handleGenerate = useCallback(async () => {
-    const currentModel = getCurrentModel();
-    const isExtendMode = currentModel?.requiresRequestId;
+    const currentModel = currentModelObj;
     const trimmedPrompt = prompt.trim();
 
     if (v2vMode) {
@@ -1136,18 +1246,20 @@ export default function VideoStudio({
         return;
       }
       if (currentModel?.imageField && !uploadedImageUrl) {
-        alert("Please upload a reference image for motion control.");
+        alert(`Please upload the required image for ${currentModel.name}.`);
         return;
       }
-      if (currentModel?.promptRequired && !trimmedPrompt) {
-        alert("Please describe the motion you want.");
+      if (currentToolPresentation.promptRequired && !trimmedPrompt) {
+        alert(`Please enter instructions for ${currentModel.name}.`);
         return;
       }
-    } else if (isExtendMode) {
-      if (!lastGenerationId) {
-        alert(
-          "No Seedance 2.0 generation found to extend. Generate a video first.",
-        );
+    } else if (continuationConfig) {
+      if (!selectedContinuationSource) {
+        alert(continuationConfig.emptySourceMessage);
+        return;
+      }
+      if (continuationConfig.promptRequired && !trimmedPrompt) {
+        alert(`Please enter instructions for ${currentModel.name}.`);
         return;
       }
     } else if (imageMode) {
@@ -1174,8 +1286,6 @@ export default function VideoStudio({
     setGenerating(true);
     setGenerateError(null);
 
-    let hadError = false;
-
     try {
       let res;
 
@@ -1185,24 +1295,26 @@ export default function VideoStudio({
         const v2vParams = {
           model: selectedModel,
           video_url: uploadedVideoUrl,
+          options: videoToolOptions,
         };
         if (currentModel?.imageField && uploadedImageUrl) {
           v2vParams.image_url = uploadedImageUrl;
         }
-        if (currentModel?.hasPrompt && trimmedPrompt) {
+        if (currentToolPresentation.showPrompt && trimmedPrompt) {
           v2vParams.prompt = trimmedPrompt;
         }
         res = await processV2V(apiKey, v2vParams);
         if (!res?.url) throw new Error("No video URL returned by API");
 
-        const genId = res.id || Date.now().toString();
-        setLastGenerationId(null);
-        setLastGenerationModel(null);
+        const requestId = res.request_id || null;
+        const genId = requestId || res.id || Date.now().toString();
         const entry = {
           id: genId,
+          requestId,
           url: res.url,
-          prompt: currentModel?.hasPrompt ? trimmedPrompt : "",
+          prompt: currentToolPresentation.showPrompt ? trimmedPrompt : "",
           model: selectedModel,
+          modelName: selectedModelName,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1211,7 +1323,8 @@ export default function VideoStudio({
           onGenerationComplete({
             url: res.url,
             model: selectedModel,
-            prompt: currentModel?.hasPrompt ? trimmedPrompt : "",
+            prompt: currentToolPresentation.showPrompt ? trimmedPrompt : "",
+            requestId,
             type: "video",
           });
       } else if (imageMode) {
@@ -1239,19 +1352,15 @@ export default function VideoStudio({
         res = await generateI2V(apiKey, i2vParams);
         if (!res?.url) throw new Error("No video URL returned by API");
 
-        const genId = res.id || Date.now().toString();
-        if (selectedModel === "seedance-v2.0-i2v") {
-          setLastGenerationId(genId);
-          setLastGenerationModel(selectedModel);
-        } else {
-          setLastGenerationId(null);
-          setLastGenerationModel(null);
-        }
+        const requestId = res.request_id || null;
+        const genId = requestId || res.id || Date.now().toString();
         const entry = {
           id: genId,
+          requestId,
           url: res.url,
           prompt: trimmedPrompt,
           model: selectedModel,
+          modelName: selectedModelName,
           aspect_ratio: selectedAr,
           duration: selectedDuration,
           timestamp: new Date().toISOString(),
@@ -1263,26 +1372,31 @@ export default function VideoStudio({
             url: res.url,
             model: selectedModel,
             prompt: trimmedPrompt,
+            requestId,
             type: "video",
           });
       } else {
-        // T2V (including extend mode)
+        // T2V, including operations based on a compatible prior request.
         const params = { model: selectedModel };
-        if (trimmedPrompt) params.prompt = trimmedPrompt;
+        const submittedPrompt =
+          continuationConfig && !currentToolPresentation.showPrompt
+            ? ""
+            : trimmedPrompt;
+        if (submittedPrompt) params.prompt = submittedPrompt;
 
-        if (isExtendMode) {
-          params.request_id = lastGenerationId;
-          // Optional reference media for Seedance 2.0 Extend:
-          // images map to @image2…@image9 and videos map to @video1…@video3 in the prompt
-          if (uploadedImageUrls.length > 0) {
+        if (continuationConfig) {
+          params.request_id = selectedContinuationSource.requestId;
+          if (currentModel?.inputs?.images_list && uploadedImageUrls.length > 0) {
             params.images_list = uploadedImageUrls;
           }
-          if (uploadedVideoUrl) {
-            params.videos_list = [uploadedVideoUrl];
+          if (currentModel?.inputs?.video_files && uploadedVideoUrl) {
+            params.video_files = [uploadedVideoUrl];
           }
         } else {
           params.aspect_ratio = selectedAr;
         }
+
+        params.options = videoToolOptions;
 
         const durations = getDurationsForModel(selectedModel);
         if (durations.length > 0) params.duration = selectedDuration;
@@ -1294,24 +1408,20 @@ export default function VideoStudio({
         res = await generateVideo(apiKey, params);
         if (!res?.url) throw new Error("No video URL returned by API");
 
-        const genId = res.id || Date.now().toString();
-        if (
-          selectedModel === "seedance-v2.0-t2v" ||
-          selectedModel === "seedance-v2.0-i2v"
-        ) {
-          setLastGenerationId(genId);
-          setLastGenerationModel(selectedModel);
-        } else {
-          setLastGenerationId(null);
-          setLastGenerationModel(null);
-        }
+        const requestId = res.request_id || null;
+        const genId = requestId || res.id || Date.now().toString();
         const entry = {
           id: genId,
+          requestId,
           url: res.url,
-          prompt: trimmedPrompt,
+          prompt: submittedPrompt,
           model: selectedModel,
-          aspect_ratio: selectedAr,
-          duration: selectedDuration,
+          modelName: selectedModelName,
+          aspect_ratio: continuationConfig ? undefined : selectedAr,
+          duration:
+            getDurationsForModel(selectedModel).length > 0
+              ? selectedDuration
+              : undefined,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1320,12 +1430,12 @@ export default function VideoStudio({
           onGenerationComplete({
             url: res.url,
             model: selectedModel,
-            prompt: trimmedPrompt,
+            prompt: submittedPrompt,
+            requestId,
             type: "video",
           });
       }
     } catch (e) {
-      hadError = true;
       console.error("[VideoStudio]", e);
       const errMsg = formatErrorMessage(e, "Video generation failed");
       if (onGenerationError) onGenerationError(errMsg);
@@ -1346,12 +1456,16 @@ export default function VideoStudio({
     selectedQuality,
     selectedMode,
     selectedEffect,
+    selectedModelName,
     showEffect,
+    videoToolOptions,
     uploadedImageUrl,
     uploadedImageUrls,
     uploadedVideoUrl,
-    lastGenerationId,
-    getCurrentModel,
+    continuationConfig,
+    currentModelObj,
+    currentToolPresentation,
+    selectedContinuationSource,
     addToLocalHistory,
     showVideoInCanvas,
     onGenerationComplete,
@@ -1377,45 +1491,67 @@ export default function VideoStudio({
     const first = t2vModels[0];
     setSelectedModel(first.id);
     setSelectedModelName(first.name);
+    setVideoToolOptions(getDefaultVideoToolOptions(first));
     applyControlsForModel(first.id, false, false);
-    setPromptDisabled(false);
     setTimeout(() => textareaRef.current?.focus(), 50);
   }, [resetToPromptBar, applyControlsForModel]);
 
-  const handleExtend = useCallback(() => {
-    if (!lastGenerationId) return;
-    resetToPromptBar();
-    setPrompt("");
-    setUploadedImageUrl(null);
-    setUploadedImageUrls([]);
-    setImageMode(false);
-    setSelectedModel("seedance-v2.0-extend");
-    setSelectedModelName("Seedance 2.0 Extend");
-    applyControlsForModel("seedance-v2.0-extend", false, false);
-    setPromptDisabled(false);
-    setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [lastGenerationId, resetToPromptBar, applyControlsForModel]);
+  const handleExtend = useCallback(
+    (entry) => {
+      if (!entry?.requestId) return;
+      const targetModel = t2vModels.find(
+        (model) => model.id === "seedance-v2.0-extend",
+      );
+      const targetConfig = getContinuationConfig(targetModel);
+      if (!targetModel || !targetConfig) return;
+
+      resetToPromptBar();
+      setPrompt("");
+      setUploadedImageUrl(null);
+      setUploadedImageUrls([]);
+      setUploadedVideoUrl(null);
+      setUploadedVideoName(null);
+      setImageMode(false);
+      setV2vMode(false);
+      setSelectedModel(targetModel.id);
+      setSelectedModelName(targetModel.name);
+      setVideoToolOptions(getDefaultVideoToolOptions(targetModel));
+      setContinuationSourceIds((previous) => ({
+        ...previous,
+        [targetConfig.family]: entry.requestId,
+      }));
+      applyControlsForModel(targetModel.id, false, false);
+      setTimeout(() => textareaRef.current?.focus(), 50);
+    },
+    [resetToPromptBar, applyControlsForModel],
+  );
 
   // ── derived UI values ────────────────────────────────────────────────────
-  const isSeedance2Canvas =
-    canvasModel === "seedance-v2.0-t2v" || canvasModel === "seedance-v2.0-i2v";
-  const currentModelObj = getCurrentModel();
-  const isExtendMode = currentModelObj?.requiresRequestId;
+  const isContinuationMode = Boolean(continuationConfig);
   const canUploadImageReference =
     (!v2vMode || isMotionControlSelection(selectedModel, v2vMode)) &&
-    (!isExtendMode || currentModelObj?.inputs?.images_list);
+    (!isContinuationMode || currentModelObj?.inputs?.images_list);
+
+  const showPromptField =
+    v2vMode || isContinuationMode
+      ? currentToolPresentation.showPrompt
+      : true;
 
   const promptPlaceholder = v2vMode
-    ? currentModelObj?.imageField
-      ? currentModelObj?.promptRequired
-        ? "Describe the motion"
-        : "Describe the motion (optional)"
-      : "Video ready — click Generate to remove watermark"
+    ? currentToolPresentation.promptPlaceholder
     : imageMode
       ? "Describe the motion or effect (optional)"
-      : isExtendMode
-        ? "Optional: describe how to continue the video..."
+      : isContinuationMode
+        ? currentToolPresentation.promptPlaceholder
         : "Describe the video you want to create";
+
+  const generateActionLabel =
+    v2vMode || isContinuationMode
+      ? currentToolPresentation.actionLabel
+      : "Generate";
+  const videoUploadTitle = v2vMode
+    ? currentToolPresentation.uploadTitle
+    : `Upload reference video for ${currentModelObj?.name || "this model"}`;
 
   const toggleDropdown = (type) => (e) => {
     e.stopPropagation();
@@ -1433,7 +1569,10 @@ export default function VideoStudio({
         {history.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full pt-4 animate-fade-in-up">
             {history.map((entry, idx) => {
-              const isSeedance2 = entry.model === "seedance-v2.0-t2v" || entry.model === "seedance-v2.0-i2v";
+              const canExtendWithSeedance =
+                Boolean(entry.requestId) &&
+                (entry.model === "seedance-v2.0-t2v" ||
+                  entry.model === "seedance-v2.0-i2v");
               return (
                 <div
                   key={entry.id || idx}
@@ -1473,14 +1612,13 @@ export default function VideoStudio({
                         <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
                       </svg>
                     </button>
-                    {isSeedance2 && (
+                    {canExtendWithSeedance && (
                       <button
                         type="button"
                         title="Extend this video using Seedance 2.0 Extend"
                         onClick={(e) => {
                           e.stopPropagation();
-                          setLastGenerationId(entry.id);
-                          handleExtend();
+                          handleExtend(entry);
                         }}
                         className="p-2 bg-black/60 backdrop-blur-md rounded-full text-white hover:bg-primary hover:text-black transition-all border border-white/10"
                       >
@@ -1520,13 +1658,10 @@ export default function VideoStudio({
                         onSelect: () =>
                           downloadFile(entry.url, `video-${entry.id || idx}.mp4`),
                       },
-                      isSeedance2 && {
+                      canExtendWithSeedance && {
                         kind: "extend",
                         label: "Extend",
-                        onSelect: () => {
-                          setLastGenerationId(entry.id);
-                          handleExtend();
-                        },
+                        onSelect: () => handleExtend(entry),
                       },
                       {
                         kind: "delete",
@@ -1841,7 +1976,7 @@ export default function VideoStudio({
                   />
                   <button
                     type="button"
-                    title="Upload video to remove watermark"
+                    title={videoUploadTitle}
                     onClick={() => videoFileInputRef.current?.click()}
                     className={promptMediaButtonClassName()}
                   >
@@ -1882,20 +2017,25 @@ export default function VideoStudio({
               )}
             </div>
 
-            {/* Prompt textarea */}
+            {/* Prompt or operation summary */}
             <div className="flex-1 flex flex-col gap-1">
-              <PromptTextarea
-                ref={textareaRef}
-                value={prompt}
-                onChange={handlePromptInput}
-                placeholder={promptPlaceholder}
-                disabled={promptDisabled}
-              />
+              {showPromptField ? (
+                <PromptTextarea
+                  ref={textareaRef}
+                  value={prompt}
+                  onChange={handlePromptInput}
+                  placeholder={promptPlaceholder}
+                />
+              ) : (
+                <div className="min-h-[58px] flex items-center px-3 text-xs leading-relaxed text-white/55">
+                  {currentToolPresentation.summary}
+                </div>
+              )}
             </div>
           </div>
 
-          {/* Extend banner */}
-          {isExtendMode && (
+          {/* Compatible source status */}
+          {isContinuationMode && (
             <div className="flex items-center gap-2 px-3 py-1.5 mx-3 bg-primary/5 border border-primary/10 rounded-lg text-[10px] text-primary/80 font-medium tracking-tight">
               <svg
                 width="13"
@@ -1907,7 +2047,11 @@ export default function VideoStudio({
               >
                 <path d="M5 12h14M12 5l7 7-7 7" />
               </svg>
-              <span>Extending previous Seedance 2.0 generation</span>
+              <span>
+                {selectedContinuationSource
+                  ? `Using ${selectedContinuationSource.modelName || selectedContinuationSource.model} as source`
+                  : continuationConfig.emptySourceMessage}
+              </span>
             </div>
           )}
 
@@ -1958,6 +2102,98 @@ export default function VideoStudio({
                   </PromptPopover>
                 )}
               </div>
+
+              {isContinuationMode && (
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={toggleDropdown("continuation-source")}
+                    className={promptControlClassName({
+                      active: openDropdown === "continuation-source",
+                    })}
+                    title={continuationConfig.sourceLabel}
+                  >
+                    {selectedContinuationSource ? (
+                      <video
+                        src={selectedContinuationSource.url}
+                        muted
+                        playsInline
+                        preload="metadata"
+                        className="w-5 h-5 rounded object-cover bg-black/50"
+                      />
+                    ) : (
+                      <VideoIconSvg className="w-4 h-4 opacity-40" />
+                    )}
+                    <span className={`${PROMPT_CONTROL_LABEL_CLASS} max-w-[150px] truncate`}>
+                      {selectedContinuationSource?.modelName || "Select source video"}
+                    </span>
+                    <PromptChevronIcon />
+                  </button>
+                  {openDropdown === "continuation-source" && (
+                    <PromptPopover
+                      onClick={(event) => event.stopPropagation()}
+                      className="min-w-[300px] max-h-[360px]"
+                    >
+                      <PromptPopoverHeader>
+                        {continuationConfig.sourceLabel}
+                      </PromptPopoverHeader>
+                      <PromptMenuList>
+                        {compatibleContinuationSources.length > 0 ? (
+                          compatibleContinuationSources.map((entry) => (
+                            <button
+                              key={entry.requestId}
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setContinuationSourceIds((previous) => ({
+                                  ...previous,
+                                  [continuationConfig.family]: entry.requestId,
+                                }));
+                                setOpenDropdown(null);
+                              }}
+                              className="w-full flex items-center gap-3 rounded-xl px-2 py-2 text-left hover:bg-white/5 transition-colors"
+                            >
+                              <video
+                                src={entry.url}
+                                muted
+                                playsInline
+                                preload="metadata"
+                                className="w-16 h-10 rounded-lg object-cover bg-black/50 shrink-0"
+                              />
+                              <span className="min-w-0 flex-1">
+                                <span className="block text-xs font-bold text-white truncate">
+                                  {entry.modelName || entry.model}
+                                </span>
+                                <span className="block text-[9px] text-white/35 truncate">
+                                  {entry.requestId}
+                                </span>
+                              </span>
+                              {selectedContinuationSource?.requestId === entry.requestId && (
+                                <CheckSvg />
+                              )}
+                            </button>
+                          ))
+                        ) : (
+                          <div className="px-3 py-4 text-xs leading-relaxed text-white/45">
+                            {continuationConfig.emptySourceMessage}
+                          </div>
+                        )}
+                      </PromptMenuList>
+                    </PromptPopover>
+                  )}
+                </div>
+              )}
+
+              <VideoToolOptionControls
+                definitions={videoToolOptionDefinitions}
+                values={videoToolOptions}
+                onChange={(key, value) =>
+                  setVideoToolOptions((previous) => ({ ...previous, [key]: value }))
+                }
+                openDropdown={openDropdown}
+                setOpenDropdown={setOpenDropdown}
+                toggleDropdown={toggleDropdown}
+              />
 
               {/* Aspect ratio btn */}
               {showAr && (
@@ -2175,7 +2411,7 @@ export default function VideoStudio({
                 </>
               ) : (
                 <>
-                  <span>Generate</span>
+                  <span>{generateActionLabel}</span>
                 </>
               )}
             </PromptAction>

--- a/packages/studio/src/components/VideoStudio.jsx
+++ b/packages/studio/src/components/VideoStudio.jsx
@@ -2,7 +2,13 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import toast, { Toaster } from "react-hot-toast";
-import { generateVideo, generateI2V, processV2V, uploadFile } from "../muapi.js";
+import {
+  estimateV2VCost,
+  generateVideo,
+  generateI2V,
+  processV2V,
+  uploadFile,
+} from "../muapi.js";
 import { formatErrorMessage } from "../utils/formatError.js";
 import { scopedPersistKey, migrateLegacyPersistKey } from "../persistKey.js";
 import {
@@ -57,6 +63,89 @@ import {
 function getQualitiesForModel(modelList, modelId) {
   const model = modelList.find((m) => m.id === modelId);
   return model?.inputs?.quality?.enum || [];
+}
+
+function formatCost({ cost, currency }) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 4,
+  }).format(cost);
+}
+
+const DEFAULT_VIDEO_MAX_BYTES = 50 * 1024 * 1024;
+
+function getVideoFileError(file, constraints) {
+  const maxBytes = constraints?.maxBytes || DEFAULT_VIDEO_MAX_BYTES;
+  if (file.size > maxBytes) {
+    return `Video exceeds the ${Math.round(maxBytes / 1024 / 1024)}MB limit.`;
+  }
+  if (!constraints) return null;
+
+  const mimeType = file.type.toLowerCase();
+  const extension = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+  const hasAllowedType = constraints.allowedMimeTypes.includes(mimeType);
+  const hasAllowedExtension = constraints.allowedExtensions.includes(extension);
+  return hasAllowedType || hasAllowedExtension
+    ? null
+    : `Unsupported video format. ${constraints.requirements}`;
+}
+
+function readVideoMetadata(file) {
+  return new Promise((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file);
+    const video = document.createElement("video");
+    let timeoutId;
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      video.onloadedmetadata = null;
+      video.onerror = null;
+      video.removeAttribute("src");
+      video.load();
+      URL.revokeObjectURL(objectUrl);
+    };
+
+    video.preload = "metadata";
+    video.onloadedmetadata = () => {
+      const metadata = {
+        duration: video.duration,
+        width: video.videoWidth,
+        height: video.videoHeight,
+      };
+      cleanup();
+      resolve(metadata);
+    };
+    video.onerror = () => {
+      cleanup();
+      reject(new Error("The selected video's metadata could not be read."));
+    };
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("The selected video's metadata could not be read."));
+    }, 10000);
+    video.src = objectUrl;
+  });
+}
+
+function getVideoMetadataError(metadata, constraints) {
+  if (!constraints) return null;
+  if (
+    !Number.isFinite(metadata.duration) ||
+    metadata.duration < constraints.minDurationSeconds ||
+    metadata.duration > constraints.maxDurationSeconds
+  ) {
+    return `Video duration must be between ${constraints.minDurationSeconds} and ${constraints.maxDurationSeconds} seconds.`;
+  }
+
+  const shortSide = Math.min(metadata.width, metadata.height);
+  const longSide = Math.max(metadata.width, metadata.height);
+  if (
+    shortSide < constraints.minShortSide ||
+    longSide > constraints.maxLongSide
+  ) {
+    return `Video dimensions must have a shorter side of at least ${constraints.minShortSide}px and a longer side of at most ${constraints.maxLongSide}px.`;
+  }
+  return null;
 }
 
 async function downloadFile(url, filename) {
@@ -480,8 +569,48 @@ function VideoToolOptionControls({
     }
 
     const dropdownId = `video-option:${definition.key}`;
+    if (definition.type === "string" && !definition.enum) {
+      return (
+        <div key={definition.key} className="relative">
+          <button
+            type="button"
+            onClick={toggleDropdown(dropdownId)}
+            className={promptControlClassName({
+              active: openDropdown === dropdownId || Boolean(value),
+            })}
+            title={definition.title}
+          >
+            <PromptQualityIcon />
+            <span className={`${PROMPT_CONTROL_LABEL_CLASS} max-w-[140px] truncate`}>
+              {value || definition.title}
+            </span>
+            <PromptChevronIcon />
+          </button>
+          {openDropdown === dropdownId && (
+            <PromptPopover
+              onClick={(event) => event.stopPropagation()}
+              className="min-w-[280px]"
+            >
+              <PromptPopoverHeader>{definition.title}</PromptPopoverHeader>
+              <input
+                type="text"
+                value={value || ""}
+                onChange={(event) => onChange(definition.key, event.target.value)}
+                placeholder={definition.title}
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white placeholder:text-white/25 outline-none focus:border-primary/50"
+              />
+            </PromptPopover>
+          )}
+        </div>
+      );
+    }
+
     const valueLabel =
-      definition.key === "upscale_factor" ? `${value}×` : String(value ?? "");
+      definition.key === "upscale_factor"
+        ? `${value}×`
+        : definition.key === "duration" || definition.key === "extend_times"
+          ? `${value}s`
+          : String(value ?? definition.title);
 
     return (
       <div key={definition.key} className="relative">
@@ -504,6 +633,18 @@ function VideoToolOptionControls({
           >
             <PromptPopoverHeader>{definition.title}</PromptPopoverHeader>
             <PromptMenuList>
+              {definition.optional && (
+                <PromptMenuItem
+                  selected={value === undefined}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onChange(definition.key, undefined);
+                    setOpenDropdown(null);
+                  }}
+                >
+                  Default
+                </PromptMenuItem>
+              )}
               {(definition.enum || []).map((option) => (
                 <PromptMenuItem
                   key={option}
@@ -596,10 +737,14 @@ export default function VideoStudio({
   const [uploadedVideoUrl, setUploadedVideoUrl] = useState(null);
   const [videoUploading, setVideoUploading] = useState(false);
   const [uploadedVideoName, setUploadedVideoName] = useState(null);
+  const [uploadedVideoValidationKey, setUploadedVideoValidationKey] =
+    useState(null);
 
   // ── generation / canvas ──
   const [generating, setGenerating] = useState(false);
   const [generateError, setGenerateError] = useState(null);
+  const [costEstimate, setCostEstimate] = useState({ status: "idle" });
+  const [costEstimateRetry, setCostEstimateRetry] = useState(0);
   const [fullscreenUrl, setFullscreenUrl] = useState(null);
   const [canvasUrl, setCanvasUrl] = useState(null);
   const [showCanvas, setShowCanvas] = useState(false);
@@ -624,6 +769,18 @@ export default function VideoStudio({
   const videoFileInputRef = useRef(null);
   const resultVideoRef = useRef(null);
   const hasRestored = useRef(false);
+  const costEstimateRequestRef = useRef(0);
+  const videoUploadRequestRef = useRef(0);
+  const activeVideoUploadContextRef = useRef(null);
+
+  const currentVideoUploadContext = `${v2vMode ? "v2v" : imageMode ? "i2v" : "t2v"}:${selectedModel}`;
+  activeVideoUploadContextRef.current = currentVideoUploadContext;
+
+  const cancelPendingVideoUpload = useCallback(() => {
+    videoUploadRequestRef.current += 1;
+    setVideoUploading(false);
+    setVideoProgress(0);
+  }, []);
 
   // ── derived data ──
   const history = historyItems ?? localHistory;
@@ -677,6 +834,11 @@ export default function VideoStudio({
     () => getVideoToolPresentation(currentModelObj),
     [currentModelObj],
   );
+  const currentVideoValidationKey =
+    currentToolPresentation.videoConstraints?.key || null;
+  const uploadedVideoIsValidated =
+    !currentVideoValidationKey ||
+    uploadedVideoValidationKey === currentVideoValidationKey;
   const continuationConfig = useMemo(
     () => getContinuationConfig(currentModelObj),
     [currentModelObj],
@@ -691,7 +853,7 @@ export default function VideoStudio({
     return (
       compatibleContinuationSources.find(
         (entry) => entry.requestId === selectedRequestId,
-      ) || compatibleContinuationSources[0] || null
+      ) || null
     );
   }, [
     compatibleContinuationSources,
@@ -702,6 +864,101 @@ export default function VideoStudio({
     () => getVideoToolOptionDefinitions(currentModelObj),
     [currentModelObj],
   );
+  const v2vRequestParams = useMemo(() => {
+    if (!v2vMode || !currentModelObj) return null;
+
+    const params = {
+      model: selectedModel,
+      video_url: uploadedVideoUrl,
+      options: videoToolOptions,
+    };
+    if (currentModelObj.imageField && uploadedImageUrl) {
+      params.image_url = uploadedImageUrl;
+    }
+
+    const trimmedPrompt = prompt.trim();
+    if (currentToolPresentation.showPrompt && trimmedPrompt) {
+      params.prompt = trimmedPrompt;
+    }
+    return params;
+  }, [
+    currentModelObj,
+    currentToolPresentation.showPrompt,
+    prompt,
+    selectedModel,
+    uploadedImageUrl,
+    uploadedVideoUrl,
+    v2vMode,
+    videoToolOptions,
+  ]);
+  const costEstimateKey = useMemo(
+    () =>
+      currentToolPresentation.estimateCost && v2vRequestParams
+        ? JSON.stringify(v2vRequestParams)
+        : null,
+    [currentToolPresentation.estimateCost, v2vRequestParams],
+  );
+  const hasCompleteCostInputs = Boolean(
+    costEstimateKey &&
+      uploadedVideoUrl &&
+      uploadedVideoIsValidated &&
+      (!currentModelObj?.imageField || uploadedImageUrl) &&
+      (!currentToolPresentation.promptRequired || v2vRequestParams?.prompt),
+  );
+
+  useEffect(() => {
+    const requestVersion = ++costEstimateRequestRef.current;
+    if (!costEstimateKey) {
+      setCostEstimate({ status: "idle" });
+      return undefined;
+    }
+    if (!hasCompleteCostInputs) {
+      setCostEstimate({ status: "waiting", key: costEstimateKey });
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    setCostEstimate({ status: "loading", key: costEstimateKey });
+    const timer = setTimeout(() => {
+      estimateV2VCost(v2vRequestParams, controller.signal)
+        .then((estimate) => {
+          if (costEstimateRequestRef.current !== requestVersion) return;
+          setCostEstimate({ status: "ready", key: costEstimateKey, ...estimate });
+        })
+        .catch((error) => {
+          if (
+            error.name === "AbortError" ||
+            costEstimateRequestRef.current !== requestVersion
+          ) {
+            return;
+          }
+          setCostEstimate({
+            status: "error",
+            key: costEstimateKey,
+          });
+        });
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [
+    costEstimateKey,
+    costEstimateRetry,
+    hasCompleteCostInputs,
+    v2vRequestParams,
+  ]);
+
+  useEffect(() => {
+    if (!uploadedVideoUrl || uploadedVideoIsValidated) return;
+    setUploadedVideoUrl(null);
+    setUploadedVideoName(null);
+    setUploadedVideoValidationKey(null);
+    toast.error(
+      "Re-upload the source video so its requirements can be validated for this tool.",
+    );
+  }, [uploadedVideoIsValidated, uploadedVideoUrl]);
 
   const isMotionControlSelection = useCallback(
     (modelId, isV2v) => {
@@ -806,13 +1063,14 @@ export default function VideoStudio({
         if (data.selectedQuality) setSelectedQuality(data.selectedQuality);
         if (data.selectedMode) setSelectedMode(data.selectedMode);
         if (data.selectedEffect) setSelectedEffect(data.selectedEffect);
-        if (data.videoToolOptions) {
-          setVideoToolOptions(data.videoToolOptions);
-        } else if (data.selectedModel) {
+        if (data.selectedModel) {
           const restoredModel = [...t2vModels, ...i2vModels, ...v2vModels].find(
             (model) => model.id === data.selectedModel,
           );
-          setVideoToolOptions(getDefaultVideoToolOptions(restoredModel));
+          setVideoToolOptions({
+            ...getDefaultVideoToolOptions(restoredModel),
+            ...(data.videoToolOptions || {}),
+          });
         }
         if (data.continuationSourceIds) {
           setContinuationSourceIds(data.continuationSourceIds);
@@ -825,6 +1083,9 @@ export default function VideoStudio({
         }
         if (data.uploadedVideoUrl) setUploadedVideoUrl(data.uploadedVideoUrl);
         if (data.uploadedVideoName) setUploadedVideoName(data.uploadedVideoName);
+        if (data.uploadedVideoValidationKey) {
+          setUploadedVideoValidationKey(data.uploadedVideoValidationKey);
+        }
         if (data.prompt) setPrompt(data.prompt);
         if (data.localHistory) setLocalHistory(data.localHistory);
 
@@ -863,6 +1124,7 @@ export default function VideoStudio({
           uploadedImageUrls,
           uploadedVideoUrl,
           uploadedVideoName,
+          uploadedVideoValidationKey,
           prompt,
           localHistory,
         };
@@ -889,6 +1151,7 @@ export default function VideoStudio({
     uploadedImageUrls,
     uploadedVideoUrl,
     uploadedVideoName,
+    uploadedVideoValidationKey,
     prompt,
     localHistory,
   ]);
@@ -919,8 +1182,10 @@ export default function VideoStudio({
         return;
       }
 
+      cancelPendingVideoUpload();
       setUploadedVideoUrl(null);
       setUploadedVideoName(null);
+      setUploadedVideoValidationKey(null);
       setV2vMode(false);
 
       const sibling = currentT2V?.family
@@ -951,6 +1216,7 @@ export default function VideoStudio({
     },
     [
       applyControlsForModel,
+      cancelPendingVideoUpload,
       imageMode,
       isMotionControlSelection,
       selectedModel,
@@ -989,7 +1255,7 @@ export default function VideoStudio({
   );
 
   const applyUploadedVideo = useCallback(
-    (url, name) => {
+    (url, name, validationKey = null) => {
       const mode = v2vMode ? "v2v" : imageMode ? "i2v" : "t2v";
       const transition = resolveVideoUploadTransition({
         mode,
@@ -999,6 +1265,7 @@ export default function VideoStudio({
 
       setUploadedVideoUrl(url);
       setUploadedVideoName(name);
+      setUploadedVideoValidationKey(validationKey);
 
       if (transition.clearImage) {
         setUploadedImageUrl(null);
@@ -1027,25 +1294,63 @@ export default function VideoStudio({
     ],
   );
 
-  const processDroppedVideo = useCallback(
+  const uploadVideo = useCallback(
     async (file) => {
-      if (file.size > 50 * 1024 * 1024) {
-        alert("Video exceeds 50MB limit.");
+      const constraints = currentToolPresentation.videoConstraints;
+      const fileError = getVideoFileError(file, constraints);
+      if (fileError) {
+        alert(fileError);
         return;
       }
+
+      const requestVersion = ++videoUploadRequestRef.current;
+      const uploadContext = currentVideoUploadContext;
+      const isCurrentUpload = () =>
+        videoUploadRequestRef.current === requestVersion &&
+        activeVideoUploadContextRef.current === uploadContext;
+
       setVideoUploading(true);
       setVideoProgress(0);
       try {
-        const url = await uploadFile(apiKey, file, setVideoProgress);
-        applyUploadedVideo(url, file.name);
+        if (constraints) {
+          let metadata;
+          try {
+            metadata = await readVideoMetadata(file);
+          } catch (error) {
+            if (isCurrentUpload()) alert(error.message);
+            return;
+          }
+          if (!isCurrentUpload()) return;
+          const metadataError = getVideoMetadataError(metadata, constraints);
+          if (metadataError) {
+            alert(metadataError);
+            return;
+          }
+        }
+
+        if (!isCurrentUpload()) return;
+        const url = await uploadFile(apiKey, file, (progress) => {
+          if (isCurrentUpload()) setVideoProgress(progress);
+        });
+        if (!isCurrentUpload()) return;
+        applyUploadedVideo(url, file.name, constraints?.key || null);
       } catch (err) {
-        alert(`Video upload failed: ${err.message}`);
+        if (isCurrentUpload()) {
+          alert(`Video upload failed: ${err.message}`);
+        }
       } finally {
-        setVideoUploading(false);
-        setVideoProgress(0);
+        if (videoUploadRequestRef.current === requestVersion) {
+          setVideoUploading(false);
+          setVideoProgress(0);
+        }
       }
     },
-    [apiKey, applyUploadedVideo],
+    [
+      apiKey,
+      applyUploadedVideo,
+      currentToolPresentation.videoConstraints,
+      currentVideoUploadContext,
+    ],
   );
 
   // ── Handle Dropped Files ────────────────────────────────────────────────
@@ -1055,13 +1360,13 @@ export default function VideoStudio({
       const videoFiles = droppedFiles.filter(f => f.type.startsWith('video/'));
       
       if (videoFiles.length > 0) {
-        processDroppedVideo(videoFiles[0]);
+        uploadVideo(videoFiles[0]);
       } else if (imageFiles.length > 0) {
         uploadImageReference(imageFiles[0]);
       }
       onFilesHandled?.();
     }
-  }, [droppedFiles, onFilesHandled, processDroppedVideo, uploadImageReference]);
+  }, [droppedFiles, onFilesHandled, uploadImageReference, uploadVideo]);
 
   // Initialise controls for default model on mount
   useEffect(() => {
@@ -1105,6 +1410,7 @@ export default function VideoStudio({
     if (isMotionControlSelection(selectedModel, v2vMode)) return;
     const currentT2V = t2vModels.find((m) => m.id === selectedModel);
     if (currentT2V?.inputs?.images_list) return;
+    cancelPendingVideoUpload();
     setImageMode(false);
     const first = t2vModels[0];
     setSelectedModel(first.id);
@@ -1119,6 +1425,7 @@ export default function VideoStudio({
       setUploadedImageUrl(null);
       // Reset to text-to-video if empty list
       if (isMotionControlSelection(selectedModel, v2vMode)) return;
+      cancelPendingVideoUpload();
       setImageMode(false);
       const first = t2vModels[0];
       setSelectedModel(first.id);
@@ -1159,35 +1466,24 @@ export default function VideoStudio({
   const handleVideoFileChange = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    if (file.size > 50 * 1024 * 1024) {
-      alert("Video exceeds 50MB limit.");
-      return;
-    }
-    setVideoUploading(true);
-    setVideoProgress(0);
     try {
-      const url = await uploadFile(apiKey, file, (pct) => {
-        setVideoProgress(pct);
-      });
-      applyUploadedVideo(url, file.name);
-    } catch (err) {
-      console.error("[VideoStudio] Video upload failed:", err);
-      alert(`Video upload failed: ${err.message}`);
+      await uploadVideo(file);
     } finally {
-      setVideoUploading(false);
-      setVideoProgress(0);
       if (videoFileInputRef.current) videoFileInputRef.current.value = "";
     }
   };
 
   const clearVideoUpload = () => {
+    cancelPendingVideoUpload();
     setUploadedVideoUrl(null);
     setUploadedVideoName(null);
+    setUploadedVideoValidationKey(null);
   };
 
   // ── model selection from dropdown ─────────────────────────────────────────
   const handleModelSelect = useCallback(
     (m, category = imageMode ? "i2v" : "t2v") => {
+      cancelPendingVideoUpload();
       const isV2V = category === "v2v";
       if (isV2V) {
         setV2vMode(true);
@@ -1206,6 +1502,7 @@ export default function VideoStudio({
           setV2vMode(false);
           setUploadedVideoUrl(null);
           setUploadedVideoName(null);
+          setUploadedVideoValidationKey(null);
         }
         const nextImageMode = category === "i2v";
         if (!nextImageMode && imageMode) {
@@ -1220,7 +1517,7 @@ export default function VideoStudio({
         applyControlsForModel(m.id, nextImageMode, false);
       }
     },
-    [v2vMode, imageMode, applyControlsForModel],
+    [v2vMode, imageMode, applyControlsForModel, cancelPendingVideoUpload],
   );
 
   // ── add to local history ──────────────────────────────────────────────────
@@ -1243,6 +1540,10 @@ export default function VideoStudio({
     if (v2vMode) {
       if (!uploadedVideoUrl) {
         alert("Please upload a video first.");
+        return;
+      }
+      if (!uploadedVideoIsValidated) {
+        alert("Please re-upload the video so its requirements can be validated.");
         return;
       }
       if (currentModel?.imageField && !uploadedImageUrl) {
@@ -1282,6 +1583,14 @@ export default function VideoStudio({
       }
     }
 
+    if (
+      currentToolPresentation.estimateCost &&
+      (costEstimate.status !== "ready" || costEstimate.key !== costEstimateKey)
+    ) {
+      alert("Wait for the current cost estimate before starting this operation.");
+      return;
+    }
+
     onGenerationStart?.();
     setGenerating(true);
     setGenerateError(null);
@@ -1292,18 +1601,7 @@ export default function VideoStudio({
       if (v2vMode) {
         // V2V: dedicated processV2V handles single-input tools (e.g. watermark
         // remover) and motion-control models (which take video + image + prompt)
-        const v2vParams = {
-          model: selectedModel,
-          video_url: uploadedVideoUrl,
-          options: videoToolOptions,
-        };
-        if (currentModel?.imageField && uploadedImageUrl) {
-          v2vParams.image_url = uploadedImageUrl;
-        }
-        if (currentToolPresentation.showPrompt && trimmedPrompt) {
-          v2vParams.prompt = trimmedPrompt;
-        }
-        res = await processV2V(apiKey, v2vParams);
+        res = await processV2V(apiKey, v2vRequestParams);
         if (!res?.url) throw new Error("No video URL returned by API");
 
         const requestId = res.request_id || null;
@@ -1318,7 +1616,7 @@ export default function VideoStudio({
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
-        showVideoInCanvas(res.url, selectedModel);
+        showVideoInCanvas(res.url);
         if (onGenerationComplete)
           onGenerationComplete({
             url: res.url,
@@ -1344,7 +1642,9 @@ export default function VideoStudio({
         const durations = getDurationsForI2VModel(selectedModel);
         if (durations.length > 0) i2vParams.duration = selectedDuration;
         const resolutions = getResolutionsForI2VModel(selectedModel);
-        if (resolutions.length > 0) i2vParams.resolution = selectedResolution;
+        const resolution =
+          resolutions.length > 0 ? selectedResolution : undefined;
+        if (resolution) i2vParams.resolution = resolution;
         if (selectedQuality) i2vParams.quality = selectedQuality;
         if (selectedMode) i2vParams.mode = selectedMode;
         if (showEffect && selectedEffect) i2vParams.name = selectedEffect;
@@ -1363,16 +1663,18 @@ export default function VideoStudio({
           modelName: selectedModelName,
           aspect_ratio: selectedAr,
           duration: selectedDuration,
+          resolution,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
-        showVideoInCanvas(res.url, selectedModel);
+        showVideoInCanvas(res.url);
         if (onGenerationComplete)
           onGenerationComplete({
             url: res.url,
             model: selectedModel,
             prompt: trimmedPrompt,
             requestId,
+            resolution,
             type: "video",
           });
       } else {
@@ -1401,7 +1703,9 @@ export default function VideoStudio({
         const durations = getDurationsForModel(selectedModel);
         if (durations.length > 0) params.duration = selectedDuration;
         const resolutions = getResolutionsForVideoModel(selectedModel);
-        if (resolutions.length > 0) params.resolution = selectedResolution;
+        const resolution =
+          resolutions.length > 0 ? selectedResolution : undefined;
+        if (resolution) params.resolution = resolution;
         if (selectedQuality) params.quality = selectedQuality;
         if (selectedMode) params.mode = selectedMode;
 
@@ -1422,16 +1726,18 @@ export default function VideoStudio({
             getDurationsForModel(selectedModel).length > 0
               ? selectedDuration
               : undefined,
+          resolution,
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
-        showVideoInCanvas(res.url, selectedModel);
+        showVideoInCanvas(res.url);
         if (onGenerationComplete)
           onGenerationComplete({
             url: res.url,
             model: selectedModel,
             prompt: submittedPrompt,
             requestId,
+            resolution,
             type: "video",
           });
       }
@@ -1462,10 +1768,14 @@ export default function VideoStudio({
     uploadedImageUrl,
     uploadedImageUrls,
     uploadedVideoUrl,
+    uploadedVideoIsValidated,
     continuationConfig,
     currentModelObj,
     currentToolPresentation,
+    costEstimate,
+    costEstimateKey,
     selectedContinuationSource,
+    v2vRequestParams,
     addToLocalHistory,
     showVideoInCanvas,
     onGenerationComplete,
@@ -1480,6 +1790,7 @@ export default function VideoStudio({
   }, []);
 
   const handleNewPrompt = useCallback(() => {
+    cancelPendingVideoUpload();
     resetToPromptBar();
     setPrompt("");
     setUploadedImageUrl(null);
@@ -1487,6 +1798,7 @@ export default function VideoStudio({
     setImageMode(false);
     setUploadedVideoUrl(null);
     setUploadedVideoName(null);
+    setUploadedVideoValidationKey(null);
     setV2vMode(false);
     const first = t2vModels[0];
     setSelectedModel(first.id);
@@ -1494,23 +1806,26 @@ export default function VideoStudio({
     setVideoToolOptions(getDefaultVideoToolOptions(first));
     applyControlsForModel(first.id, false, false);
     setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [resetToPromptBar, applyControlsForModel]);
+  }, [resetToPromptBar, applyControlsForModel, cancelPendingVideoUpload]);
 
   const handleExtend = useCallback(
     (entry) => {
-      if (!entry?.requestId) return;
       const targetModel = t2vModels.find(
         (model) => model.id === "seedance-v2.0-extend",
       );
       const targetConfig = getContinuationConfig(targetModel);
       if (!targetModel || !targetConfig) return;
+      const source = getCompatibleContinuationSources(targetModel, [entry])[0];
+      if (!source) return;
 
+      cancelPendingVideoUpload();
       resetToPromptBar();
       setPrompt("");
       setUploadedImageUrl(null);
       setUploadedImageUrls([]);
       setUploadedVideoUrl(null);
       setUploadedVideoName(null);
+      setUploadedVideoValidationKey(null);
       setImageMode(false);
       setV2vMode(false);
       setSelectedModel(targetModel.id);
@@ -1518,12 +1833,12 @@ export default function VideoStudio({
       setVideoToolOptions(getDefaultVideoToolOptions(targetModel));
       setContinuationSourceIds((previous) => ({
         ...previous,
-        [targetConfig.family]: entry.requestId,
+        [targetConfig.family]: source.requestId,
       }));
       applyControlsForModel(targetModel.id, false, false);
       setTimeout(() => textareaRef.current?.focus(), 50);
     },
-    [resetToPromptBar, applyControlsForModel],
+    [resetToPromptBar, applyControlsForModel, cancelPendingVideoUpload],
   );
 
   // ── derived UI values ────────────────────────────────────────────────────
@@ -1549,9 +1864,20 @@ export default function VideoStudio({
     v2vMode || isContinuationMode
       ? currentToolPresentation.actionLabel
       : "Generate";
+  const currentCostEstimate =
+    costEstimate.key === costEstimateKey ? costEstimate : { status: "idle" };
+  const costEstimateReady =
+    !currentToolPresentation.estimateCost ||
+    currentCostEstimate.status === "ready";
   const videoUploadTitle = v2vMode
     ? currentToolPresentation.uploadTitle
     : `Upload reference video for ${currentModelObj?.name || "this model"}`;
+  const videoFileAccept = currentToolPresentation.videoConstraints
+    ? [
+        ...currentToolPresentation.videoConstraints.allowedMimeTypes,
+        ...currentToolPresentation.videoConstraints.allowedExtensions,
+      ].join(",")
+    : "video/*";
 
   const toggleDropdown = (type) => (e) => {
     e.stopPropagation();
@@ -1569,10 +1895,12 @@ export default function VideoStudio({
         {history.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full pt-4 animate-fade-in-up">
             {history.map((entry, idx) => {
-              const canExtendWithSeedance =
-                Boolean(entry.requestId) &&
-                (entry.model === "seedance-v2.0-t2v" ||
-                  entry.model === "seedance-v2.0-i2v");
+              const canExtendWithSeedance = Boolean(
+                getCompatibleContinuationSources(
+                  "seedance-v2.0-extend",
+                  [entry],
+                ).length,
+              );
               return (
                 <div
                   key={entry.id || idx}
@@ -1970,7 +2298,7 @@ export default function VideoStudio({
                   <input
                     ref={videoFileInputRef}
                     type="file"
-                    accept="video/*"
+                    accept={videoFileAccept}
                     className="hidden"
                     onChange={handleVideoFileChange}
                   />
@@ -2029,6 +2357,16 @@ export default function VideoStudio({
               ) : (
                 <div className="min-h-[58px] flex items-center px-3 text-xs leading-relaxed text-white/55">
                   {currentToolPresentation.summary}
+                </div>
+              )}
+              {showPromptField && currentToolPresentation.guidance && (
+                <div className="px-3 text-[10px] leading-relaxed text-white/40">
+                  {currentToolPresentation.guidance}
+                </div>
+              )}
+              {currentToolPresentation.videoConstraints?.requirements && (
+                <div className="px-3 text-[10px] leading-relaxed text-white/40">
+                  Video requirements: {currentToolPresentation.videoConstraints.requirements}
                 </div>
               )}
             </div>
@@ -2397,24 +2735,50 @@ export default function VideoStudio({
               )}
             </PromptControls>
 
-            {/* Generate button */}
-            <PromptAction
-              onClick={handleGenerate}
-              disabled={generating}
-            >
-              {generating ? (
-                <>
-                  <span className="animate-spin inline-block text-black">
-                    ◌
-                  </span>{" "}
-                  Generating...
-                </>
-              ) : (
-                <>
-                  <span>{generateActionLabel}</span>
-                </>
+            <div className="flex flex-col items-stretch sm:items-end gap-1.5 shrink-0">
+              {currentToolPresentation.estimateCost && (
+                <div className="text-[10px] text-white/55 sm:text-right px-1">
+                  {currentCostEstimate.status === "ready" ? (
+                    <span>
+                      Estimated cost: {formatCost(currentCostEstimate)}{" "}
+                      {currentCostEstimate.currency}
+                    </span>
+                  ) : currentCostEstimate.status === "loading" ? (
+                    <span>Calculating exact cost…</span>
+                  ) : currentCostEstimate.status === "error" ? (
+                    <span>
+                      Cost unavailable.{" "}
+                      <button
+                        type="button"
+                        className="text-primary hover:underline"
+                        onClick={() => setCostEstimateRetry((value) => value + 1)}
+                      >
+                        Retry
+                      </button>
+                    </span>
+                  ) : (
+                    <span>Add the required inputs to calculate cost.</span>
+                  )}
+                </div>
               )}
-            </PromptAction>
+
+              {/* Generate button */}
+              <PromptAction
+                onClick={handleGenerate}
+                disabled={generating || !costEstimateReady}
+              >
+                {generating ? (
+                  <>
+                    <span className="animate-spin inline-block text-black">
+                      ◌
+                    </span>{" "}
+                    Generating...
+                  </>
+                ) : (
+                  <span>{generateActionLabel}</span>
+                )}
+              </PromptAction>
+            </div>
           </PromptFooter>
       </PromptComposer>
 

--- a/packages/studio/src/muapi.js
+++ b/packages/studio/src/muapi.js
@@ -1,4 +1,8 @@
 import { getModelById, getVideoModelById, getI2IModelById, getI2VModelById, getV2VModelById, getRecastModelById, getLipSyncModelById, getAudioModelById } from './models.js';
+import {
+    buildVideoToolPayload,
+    serializeVideoToolOptions,
+} from './videoToolCapabilities.js';
 
 // In an http(s) browser we route through the host app's proxy (Next.js routes
 // under /api/* re-issue the call server-side) so api.muapi.ai CORS is bypassed.
@@ -39,6 +43,15 @@ async function pollForResult(requestId, key, maxAttempts = 900, interval = 2000)
     throw new Error('Generation timed out after polling.');
 }
 
+export function normalizePredictionResult(submitData, result, outputUrl) {
+    const requestId = submitData?.request_id || submitData?.id || result?.request_id || result?.id;
+    return {
+        ...result,
+        ...(requestId ? { request_id: requestId } : {}),
+        url: outputUrl,
+    };
+}
+
 async function submitAndPoll(endpoint, payload, key, onRequestId, maxAttempts = 60) {
     const url = `${BASE_URL}/api/v1/${endpoint}`;
     const response = await fetch(url, {
@@ -57,7 +70,7 @@ async function submitAndPoll(endpoint, payload, key, onRequestId, maxAttempts = 
     if (onRequestId) onRequestId(requestId);
     const result = await pollForResult(requestId, key, maxAttempts);
     const outputUrl = result.outputs?.[0] || result.url || result.output?.url;
-    return { ...result, url: outputUrl };
+    return normalizePredictionResult(submitData, result, outputUrl);
 }
 
 export async function generateImage(apiKey, params) {
@@ -130,6 +143,8 @@ export async function generateVideo(apiKey, params) {
     if (params.image_url) payload.image_url = params.image_url;
     if (params.images_list?.length > 0) payload.images_list = params.images_list;
     if (params.videos_list?.length > 0) payload.videos_list = params.videos_list;
+    if (params.video_files?.length > 0) payload.video_files = params.video_files;
+    Object.assign(payload, serializeVideoToolOptions(modelInfo, params.options));
     return submitAndPoll(endpoint, payload, apiKey, params.onRequestId, 900);
 }
 
@@ -187,14 +202,7 @@ export async function generateMarketingStudioAd(apiKey, params) {
 export async function processV2V(apiKey, params) {
     const modelInfo = getV2VModelById(params.model);
     const endpoint = modelInfo?.endpoint || params.model;
-    const videoField = modelInfo?.videoField || 'video_url';
-    const payload = { [videoField]: params.video_url };
-    if (modelInfo?.imageField && params.image_url) {
-        payload[modelInfo.imageField] = params.image_url;
-    }
-    if (modelInfo?.hasPrompt && params.prompt) {
-        payload.prompt = params.prompt;
-    }
+    const payload = buildVideoToolPayload(modelInfo, params);
     return submitAndPoll(endpoint, payload, apiKey, params.onRequestId, 900);
 }
 
@@ -916,5 +924,3 @@ export async function expandImage(apiKey, { image_url, onRequestId }) {
     const payload = { image_url };
     return submitAndPoll(endpoint, payload, apiKey, onRequestId, 90);
 }
-
-

--- a/packages/studio/src/muapi.js
+++ b/packages/studio/src/muapi.js
@@ -43,7 +43,7 @@ async function pollForResult(requestId, key, maxAttempts = 900, interval = 2000)
     throw new Error('Generation timed out after polling.');
 }
 
-export function normalizePredictionResult(submitData, result, outputUrl) {
+function normalizePredictionResult(submitData, result, outputUrl) {
     const requestId = submitData?.request_id || submitData?.id || result?.request_id || result?.id;
     return {
         ...result,
@@ -204,6 +204,46 @@ export async function processV2V(apiKey, params) {
     const endpoint = modelInfo?.endpoint || params.model;
     const payload = buildVideoToolPayload(modelInfo, params);
     return submitAndPoll(endpoint, payload, apiKey, params.onRequestId, 900);
+}
+
+export async function estimateV2VCost(params, signal) {
+    const modelInfo = getV2VModelById(params?.model);
+    const endpoint = modelInfo?.endpoint || params?.model;
+    if (!endpoint) {
+        throw new Error('A V2V model is required to estimate cost.');
+    }
+
+    const payload = buildVideoToolPayload(modelInfo, params);
+    const response = await fetch(`${BASE_URL}/api/v1/models/${endpoint}/estimate-cost`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal,
+    });
+
+    if (!response.ok) {
+        const errText = await response.text();
+        throw new Error(`Cost estimate failed: ${response.status} ${response.statusText} - ${errText.slice(0, 100)}`);
+    }
+
+    let data;
+    try {
+        data = await response.json();
+    } catch {
+        throw new Error('Cost estimate returned invalid JSON.');
+    }
+
+    if (typeof data?.cost !== 'number' || !Number.isFinite(data.cost) || data.cost < 0) {
+        throw new Error('Cost estimate returned an invalid cost.');
+    }
+    if (typeof data.currency !== 'string' || !/^[A-Za-z]{3}$/.test(data.currency.trim())) {
+        throw new Error('Cost estimate returned an invalid currency.');
+    }
+
+    return {
+        cost: data.cost,
+        currency: data.currency.trim().toUpperCase(),
+    };
 }
 
 export async function processRecast(apiKey, params) {

--- a/packages/studio/src/videoToolCapabilities.js
+++ b/packages/studio/src/videoToolCapabilities.js
@@ -179,18 +179,26 @@ const HEYGEN_TRANSLATION_LANGUAGES = Object.freeze([
   "English - American Accent",
 ]);
 
-const REQUIRED_EDIT_TOOL_IDS = Object.freeze([
+const KLING_EDIT_TOOL_IDS = Object.freeze([
   "kling-o1-video-edit",
   "kling-o1-video-edit-fast",
   "kling-o1-standard-video-edit",
-  "gemini-omni-video-edit",
-  "runway-aleph-v2v",
-  "wan2.2-edit-video",
-  "wan2.7-video-edit",
+]);
+
+const HAPPY_HORSE_EDIT_TOOL_IDS = Object.freeze([
   "happy-horse-1-video-edit-1080p",
   "happy-horse-1-video-edit-720p",
   "happy-horse-1.1-video-edit-1080p",
   "happy-horse-1.1-video-edit-720p",
+]);
+
+const REQUIRED_EDIT_TOOL_IDS = Object.freeze([
+  ...KLING_EDIT_TOOL_IDS,
+  "gemini-omni-video-edit",
+  "runway-aleph-v2v",
+  "wan2.2-edit-video",
+  "wan2.7-video-edit",
+  ...HAPPY_HORSE_EDIT_TOOL_IDS,
 ]);
 
 const REQUIRED_EXTEND_TOOL_IDS = Object.freeze([
@@ -201,11 +209,23 @@ const REQUIRED_EXTEND_TOOL_IDS = Object.freeze([
   "pixverse-v6-extend",
 ]);
 
-const KLING_EDIT_TOOL_IDS = new Set([
+const KLING_ASPECT_RATIO_TOOL_IDS = new Set([
   "kling-o1-video-edit",
   "kling-o1-video-edit-fast",
-  "kling-o1-standard-video-edit",
 ]);
+
+const HAPPY_HORSE_VIDEO_CONSTRAINTS = Object.freeze({
+  key: "happy-horse-video-edit",
+  allowedMimeTypes: Object.freeze(["video/mp4", "video/quicktime"]),
+  allowedExtensions: Object.freeze([".mp4", ".mov"]),
+  maxBytes: 100 * 1024 * 1024,
+  minDurationSeconds: 3,
+  maxDurationSeconds: 60,
+  minShortSide: 320,
+  maxLongSide: 2160,
+  requirements:
+    "MP4 or MOV, 3–60 seconds, up to 100 MB, shorter side at least 320px, and longer side at most 2160px. H.264 is recommended; frame rate above 8 fps is verified by the provider.",
+});
 
 const VIDEO_TOOL_OVERRIDES = Object.create(null);
 
@@ -226,8 +246,27 @@ for (const id of REQUIRED_EXTEND_TOOL_IDS) {
 }
 
 for (const id of KLING_EDIT_TOOL_IDS) {
+  const inputs = {};
+
+  if (KLING_ASPECT_RATIO_TOOL_IDS.has(id)) {
+    inputs.aspect_ratio = {
+      title: "Aspect ratio",
+      type: "string",
+      enum: ["16:9", "9:16", "1:1"],
+      default: "16:9",
+      configurable: true,
+    };
+  }
+  inputs.keep_original_sound = {
+    title: "Keep original sound",
+    type: "boolean",
+    default: true,
+    configurable: true,
+  };
+
   VIDEO_TOOL_OVERRIDES[id] = {
     ...VIDEO_TOOL_OVERRIDES[id],
+    inputs,
     payloadDefaults: { images_list: [] },
   };
 }
@@ -240,6 +279,8 @@ Object.assign(VIDEO_TOOL_OVERRIDES, {
   "ai-video-upscaler": {
     hasPrompt: false,
     operation: "upscale",
+    summary:
+      "Upscale the source video to the selected resolution. This integration exposes target resolution and audio preservation; it does not expose an output-format setting.",
     inputs: {
       resolution: {
         title: "Target resolution",
@@ -260,7 +301,7 @@ Object.assign(VIDEO_TOOL_OVERRIDES, {
     hasPrompt: false,
     operation: "translate",
     summary:
-      "Translate the video's speech with synchronized voice and lip movement. The source language is detected automatically.",
+      "Source language is automatic and cannot be configured in this integration. Choose a target language. Voice translation and lip sync are automatic; separate audio and subtitle settings are not available.",
     inputs: {
       language: {
         title: "Target language",
@@ -274,6 +315,8 @@ Object.assign(VIDEO_TOOL_OVERRIDES, {
   "topaz-video-upscale": {
     hasPrompt: false,
     operation: "upscale",
+    summary:
+      "Upscale the source video by the selected factor. Processing time varies; an estimate isn't available for this tool.",
     inputs: {
       upscale_factor: {
         title: "Upscale factor",
@@ -288,6 +331,7 @@ Object.assign(VIDEO_TOOL_OVERRIDES, {
     hasPrompt: true,
     promptRequired: false,
     operation: "extend",
+    estimateCost: true,
     inputs: {
       duration: {
         title: "Extend duration",
@@ -327,6 +371,8 @@ Object.assign(VIDEO_TOOL_OVERRIDES, {
     hasPrompt: false,
     promptRequired: false,
     operation: "upscale",
+    actionLabel: "Create 4K video",
+    summary: "Create a 4K version of a completed Veo 3.1 video.",
   },
   "grok-imagine-extend": {
     hasPrompt: true,
@@ -336,13 +382,86 @@ Object.assign(VIDEO_TOOL_OVERRIDES, {
       extend_times: {
         title: "Extend duration",
         type: "integer",
-        enum: Array.from({ length: 25 }, (_, index) => index + 6),
+        enum: [6, 10],
         default: 6,
         configurable: true,
       },
     },
   },
+  "runway-aleph-v2v": {
+    ...VIDEO_TOOL_OVERRIDES["runway-aleph-v2v"],
+    inputs: {
+      aspect_ratio: {
+        title: "Aspect ratio",
+        type: "string",
+        enum: ["9:16", "16:9", "1:1", "4:3", "3:4", "21:9"],
+        default: "16:9",
+        configurable: true,
+      },
+    },
+  },
+  "pixverse-v6-extend": {
+    ...VIDEO_TOOL_OVERRIDES["pixverse-v6-extend"],
+    inputs: {
+      resolution: {
+        title: "Resolution",
+        type: "string",
+        enum: ["360p", "540p", "720p", "1080p"],
+        default: "720p",
+        configurable: true,
+      },
+      duration: {
+        title: "Duration",
+        type: "integer",
+        enum: Array.from({ length: 15 }, (_, index) => index + 1),
+        default: 5,
+        configurable: true,
+      },
+      generate_audio_switch: {
+        title: "Generate audio",
+        type: "boolean",
+        default: false,
+        configurable: true,
+      },
+      negative_prompt: {
+        title: "Negative prompt",
+        type: "string",
+        configurable: true,
+        optional: true,
+      },
+      style: {
+        title: "Style",
+        type: "string",
+        enum: ["anime", "3d_animation", "clay", "comic", "cyberpunk"],
+        configurable: true,
+        optional: true,
+      },
+    },
+  },
 });
+
+VIDEO_TOOL_OVERRIDES["seedance-v1.5-pro-video-extend"] = {
+  ...VIDEO_TOOL_OVERRIDES["seedance-v1.5-pro-video-extend"],
+  estimateCost: true,
+  payloadDefaults: {
+    resolution: "720p",
+    duration: 5,
+    generate_audio: true,
+    camera_fixed: false,
+  },
+};
+
+for (const id of HAPPY_HORSE_EDIT_TOOL_IDS) {
+  VIDEO_TOOL_OVERRIDES[id] = {
+    ...VIDEO_TOOL_OVERRIDES[id],
+    estimateCost: true,
+    summary:
+      "Edit a source video with a required natural-language instruction.",
+    guidance:
+      "Upload one source video that meets the listed requirements, then describe the edit you want.",
+    videoConstraints: HAPPY_HORSE_VIDEO_CONSTRAINTS,
+  };
+}
 
 const ACTION_LABELS = Object.freeze({
   edit: "Edit video",
@@ -377,22 +496,21 @@ const CONTINUATION_FAMILIES = Object.freeze({
     sourceModelIds: Object.freeze([
       "veo3.1-text-to-video",
       "veo3.1-fast-text-to-video",
-      "veo3.1-lite-text-to-video",
       "veo3.1-image-to-video",
       "veo3.1-fast-image-to-video",
-      "veo3.1-lite-image-to-video",
       "veo3.1-reference-to-video",
-      "veo3.1-extend-video",
     ]),
-    sourceLabel: "Veo 3.1 source video",
-    emptySourceMessage:
-      "Select a completed Veo 3.1 video before running this operation.",
+    sourceDefaultResolutions: Object.freeze({
+      "veo3.1-text-to-video": "1080p",
+      "veo3.1-fast-text-to-video": "1080p",
+      "veo3.1-image-to-video": "1080p",
+      "veo3.1-fast-image-to-video": "1080p",
+    }),
   },
   grok: {
     sourceModelIds: Object.freeze([
       "grok-imagine-text-to-video",
       "grok-imagine-image-to-video",
-      "grok-imagine-extend",
     ]),
     sourceLabel: "Grok Imagine source video",
     emptySourceMessage:
@@ -401,17 +519,28 @@ const CONTINUATION_FAMILIES = Object.freeze({
 });
 
 const CONTINUATION_TARGETS = Object.freeze({
-  "seedance-v2.0-extend": { family: "seedance", promptRequired: false },
-  "seedance-2-extend": { family: "seedance", promptRequired: false },
-  "seedance-2-vip-extend": { family: "seedance", promptRequired: false },
-  "seedance-2-vip-extend-1080p": {
-    family: "seedance",
-    promptRequired: false,
+  "seedance-v2.0-extend": { family: "seedance" },
+  "seedance-2-extend": { family: "seedance" },
+  "seedance-2-vip-extend": { family: "seedance" },
+  "seedance-2-vip-extend-1080p": { family: "seedance" },
+  "veo3.1-extend-video": {
+    family: "veo31",
+    requiredSourceResolution: "720p",
+    sourceLabel: "Veo 3.1 or Fast 720p source video",
+    emptySourceMessage:
+      "Select a completed 720p Veo 3.1 or Veo 3.1 Fast video before extending it.",
   },
-  "veo3.1-extend-video": { family: "veo31", promptRequired: true },
-  "veo3.1-4k-video": { family: "veo31", promptRequired: false },
-  "grok-imagine-extend": { family: "grok", promptRequired: true },
+  "veo3.1-4k-video": {
+    family: "veo31",
+    sourceLabel: "Veo 3.1 or Fast source video",
+    emptySourceMessage:
+      "Select a completed Veo 3.1 or Veo 3.1 Fast video before creating a 4K version.",
+  },
+  "grok-imagine-extend": { family: "grok" },
 });
+
+const MIN_CLIENT_TIMESTAMP = Date.UTC(2000, 0, 1);
+const MAX_CLIENT_TIMESTAMP = Date.UTC(2101, 0, 1);
 
 function mergeInputs(modelInputs = {}, overrideInputs = {}) {
   const inputs = { ...modelInputs };
@@ -421,7 +550,7 @@ function mergeInputs(modelInputs = {}, overrideInputs = {}) {
   return inputs;
 }
 
-export function getVideoToolCapabilities(model) {
+function getVideoToolCapabilities(model) {
   if (!model) return null;
   const override = VIDEO_TOOL_OVERRIDES[model.id] || {};
   return {
@@ -441,6 +570,9 @@ export function getVideoToolPresentation(model) {
       showPrompt: false,
       summary: "Upload a source video to continue.",
       uploadTitle: "Upload source video",
+      estimateCost: false,
+      guidance: "",
+      videoConstraints: null,
     };
   }
 
@@ -451,7 +583,8 @@ export function getVideoToolPresentation(model) {
   const promptLabel = PROMPT_LABELS[operation] || PROMPT_LABELS.process;
 
   return {
-    actionLabel: ACTION_LABELS[operation] || ACTION_LABELS.process,
+    actionLabel:
+      capabilities.actionLabel || ACTION_LABELS[operation] || ACTION_LABELS.process,
     promptPlaceholder: promptRequired ? promptLabel : `${promptLabel} (optional)`,
     promptRequired,
     showPrompt,
@@ -460,6 +593,9 @@ export function getVideoToolPresentation(model) {
       capabilities.description ||
       `${capabilities.name || "The selected tool"} is ready to process the video.`,
     uploadTitle: `Upload source video for ${capabilities.name || "this tool"}`,
+    estimateCost: Boolean(capabilities.estimateCost),
+    guidance: capabilities.guidance || "",
+    videoConstraints: capabilities.videoConstraints || null,
   };
 }
 
@@ -510,12 +646,17 @@ export function serializeVideoToolOptions(model, values = {}) {
   const payload = {};
   for (const input of getVideoToolOptionDefinitions(model)) {
     const value = values[input.key];
-    if (value !== undefined) payload[input.key] = value;
+    if (typeof value === "string") {
+      const normalizedValue = value.trim();
+      if (normalizedValue) payload[input.key] = normalizedValue;
+    } else if (value !== undefined && value !== null) {
+      payload[input.key] = value;
+    }
   }
   return payload;
 }
 
-export function getVideoToolPayloadDefaults(model) {
+function getVideoToolPayloadDefaults(model) {
   const capabilities = getVideoToolCapabilities(model);
   return { ...(capabilities?.payloadDefaults || {}) };
 }
@@ -545,21 +686,73 @@ export function getContinuationConfig(modelOrId) {
   const modelId = typeof modelOrId === "string" ? modelOrId : modelOrId?.id;
   const target = CONTINUATION_TARGETS[modelId];
   if (!target) return null;
+  const model = typeof modelOrId === "string" ? { id: modelId } : modelOrId;
+  const capabilities = getVideoToolCapabilities(model);
 
   return {
     ...CONTINUATION_FAMILIES[target.family],
     ...target,
+    promptRequired: Boolean(capabilities?.promptRequired),
   };
+}
+
+function normalizeRequestId(value) {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  if (typeof value === "number" && !Number.isFinite(value)) return null;
+
+  const requestId = String(value).trim();
+  if (!requestId) return null;
+
+  if (/^\d+$/.test(requestId)) {
+    const numericId = Number(requestId);
+    if (
+      Number.isFinite(numericId) &&
+      numericId >= MIN_CLIENT_TIMESTAMP &&
+      numericId < MAX_CLIENT_TIMESTAMP
+    ) {
+      return null;
+    }
+  }
+
+  return requestId;
+}
+
+function resolveContinuationRequestId(entry) {
+  if (!entry) return null;
+
+  for (const candidate of [entry.requestId, entry.request_id, entry.id]) {
+    const requestId = normalizeRequestId(candidate);
+    if (requestId) return requestId;
+  }
+
+  return null;
 }
 
 export function getCompatibleContinuationSources(modelOrId, history = []) {
   const config = getContinuationConfig(modelOrId);
   if (!config) return [];
   const compatibleModelIds = new Set(config.sourceModelIds);
+  const sources = [];
 
-  return history.filter(
-    (entry) =>
-      Boolean(entry?.requestId && entry?.url) &&
-      compatibleModelIds.has(entry.model),
-  );
+  for (const entry of history) {
+    if (!entry?.url || !compatibleModelIds.has(entry.model)) continue;
+    const requestId = resolveContinuationRequestId(entry);
+    if (!requestId) continue;
+    if (config.requiredSourceResolution) {
+      const sourceResolution =
+        entry.resolution || config.sourceDefaultResolutions?.[entry.model];
+      if (
+        String(sourceResolution).toLowerCase() !==
+        config.requiredSourceResolution.toLowerCase()
+      ) {
+        continue;
+      }
+    }
+
+    sources.push(
+      entry.requestId === requestId ? entry : { ...entry, requestId },
+    );
+  }
+
+  return sources;
 }

--- a/packages/studio/src/videoToolCapabilities.js
+++ b/packages/studio/src/videoToolCapabilities.js
@@ -1,0 +1,565 @@
+const HEYGEN_TRANSLATION_LANGUAGES = Object.freeze([
+  "English",
+  "Spanish",
+  "French",
+  "Hindi",
+  "Italian",
+  "German",
+  "Polish",
+  "Portuguese",
+  "Chinese",
+  "Japanese",
+  "Dutch",
+  "Turkish",
+  "Korean",
+  "Danish",
+  "Arabic",
+  "Romanian",
+  "Mandarin",
+  "Filipino",
+  "Swedish",
+  "Indonesian",
+  "Ukrainian",
+  "Greek",
+  "Czech",
+  "Bulgarian",
+  "Malay",
+  "Slovak",
+  "Croatian",
+  "Tamil",
+  "Finnish",
+  "Russian",
+  "Afrikaans (South Africa)",
+  "Albanian (Albania)",
+  "Amharic (Ethiopia)",
+  "Arabic (Algeria)",
+  "Arabic (Bahrain)",
+  "Arabic (Egypt)",
+  "Arabic (Iraq)",
+  "Arabic (Jordan)",
+  "Arabic (Kuwait)",
+  "Arabic (Lebanon)",
+  "Arabic (Libya)",
+  "Arabic (Morocco)",
+  "Arabic (Oman)",
+  "Arabic (Qatar)",
+  "Arabic (Saudi Arabia)",
+  "Arabic (Syria)",
+  "Arabic (Tunisia)",
+  "Arabic (United Arab Emirates)",
+  "Arabic (Yemen)",
+  "Armenian (Armenia)",
+  "Azerbaijani (Latin, Azerbaijan)",
+  "Bangla (Bangladesh)",
+  "Basque",
+  "Bengali (India)",
+  "Bosnian (Bosnia and Herzegovina)",
+  "Bulgarian (Bulgaria)",
+  "Burmese (Myanmar)",
+  "Catalan",
+  "Chinese (Cantonese, Traditional)",
+  "Chinese (Jilu Mandarin, Simplified)",
+  "Chinese (Mandarin, Simplified)",
+  "Chinese (Northeastern Mandarin, Simplified)",
+  "Chinese (Southwestern Mandarin, Simplified)",
+  "Chinese (Taiwanese Mandarin, Traditional)",
+  "Chinese (Wu, Simplified)",
+  "Chinese (Zhongyuan Mandarin Henan, Simplified)",
+  "Chinese (Zhongyuan Mandarin Shaanxi, Simplified)",
+  "Croatian (Croatia)",
+  "Czech (Czechia)",
+  "Danish (Denmark)",
+  "Dutch (Belgium)",
+  "Dutch (Netherlands)",
+  "English (Australia)",
+  "English (Canada)",
+  "English (Hong Kong SAR)",
+  "English (India)",
+  "English (Ireland)",
+  "English (Kenya)",
+  "English (New Zealand)",
+  "English (Nigeria)",
+  "English (Philippines)",
+  "English (Singapore)",
+  "English (South Africa)",
+  "English (Tanzania)",
+  "English (UK)",
+  "English (United States)",
+  "Estonian (Estonia)",
+  "Filipino (Philippines)",
+  "Finnish (Finland)",
+  "French (Belgium)",
+  "French (Canada)",
+  "French (France)",
+  "French (Switzerland)",
+  "Galician",
+  "Georgian (Georgia)",
+  "German (Austria)",
+  "German (Germany)",
+  "German (Switzerland)",
+  "Greek (Greece)",
+  "Gujarati (India)",
+  "Hebrew (Israel)",
+  "Hindi (India)",
+  "Hungarian (Hungary)",
+  "Icelandic (Iceland)",
+  "Indonesian (Indonesia)",
+  "Irish (Ireland)",
+  "Italian (Italy)",
+  "Japanese (Japan)",
+  "Javanese (Latin, Indonesia)",
+  "Kannada (India)",
+  "Kazakh (Kazakhstan)",
+  "Khmer (Cambodia)",
+  "Korean (Korea)",
+  "Lao (Laos)",
+  "Latvian (Latvia)",
+  "Lithuanian (Lithuania)",
+  "Macedonian (North Macedonia)",
+  "Malay (Malaysia)",
+  "Malayalam (India)",
+  "Maltese (Malta)",
+  "Marathi (India)",
+  "Mongolian (Mongolia)",
+  "Nepali (Nepal)",
+  "Norwegian Bokmål (Norway)",
+  "Pashto (Afghanistan)",
+  "Persian (Iran)",
+  "Polish (Poland)",
+  "Portuguese (Brazil)",
+  "Portuguese (Portugal)",
+  "Romanian (Romania)",
+  "Russian (Russia)",
+  "Serbian (Latin, Serbia)",
+  "Sinhala (Sri Lanka)",
+  "Slovak (Slovakia)",
+  "Slovenian (Slovenia)",
+  "Somali (Somalia)",
+  "Spanish (Argentina)",
+  "Spanish (Bolivia)",
+  "Spanish (Chile)",
+  "Spanish (Colombia)",
+  "Spanish (Costa Rica)",
+  "Spanish (Cuba)",
+  "Spanish (Dominican Republic)",
+  "Spanish (Ecuador)",
+  "Spanish (El Salvador)",
+  "Spanish (Equatorial Guinea)",
+  "Spanish (Guatemala)",
+  "Spanish (Honduras)",
+  "Spanish (Mexico)",
+  "Spanish (Nicaragua)",
+  "Spanish (Panama)",
+  "Spanish (Paraguay)",
+  "Spanish (Peru)",
+  "Spanish (Puerto Rico)",
+  "Spanish (Spain)",
+  "Spanish (United States)",
+  "Spanish (Uruguay)",
+  "Spanish (Venezuela)",
+  "Sundanese (Indonesia)",
+  "Swahili (Kenya)",
+  "Swahili (Tanzania)",
+  "Swedish (Sweden)",
+  "Tamil (India)",
+  "Tamil (Malaysia)",
+  "Tamil (Singapore)",
+  "Tamil (Sri Lanka)",
+  "Telugu (India)",
+  "Thai (Thailand)",
+  "Turkish (Türkiye)",
+  "Ukrainian (Ukraine)",
+  "Urdu (India)",
+  "Urdu (Pakistan)",
+  "Uzbek (Latin, Uzbekistan)",
+  "Vietnamese (Vietnam)",
+  "Welsh (United Kingdom)",
+  "Zulu (South Africa)",
+  "English - Your Accent",
+  "English - American Accent",
+]);
+
+const REQUIRED_EDIT_TOOL_IDS = Object.freeze([
+  "kling-o1-video-edit",
+  "kling-o1-video-edit-fast",
+  "kling-o1-standard-video-edit",
+  "gemini-omni-video-edit",
+  "runway-aleph-v2v",
+  "wan2.2-edit-video",
+  "wan2.7-video-edit",
+  "happy-horse-1-video-edit-1080p",
+  "happy-horse-1-video-edit-720p",
+  "happy-horse-1.1-video-edit-1080p",
+  "happy-horse-1.1-video-edit-720p",
+]);
+
+const REQUIRED_EXTEND_TOOL_IDS = Object.freeze([
+  "seedance-v1.5-pro-video-extend",
+  "seedance-v1.5-pro-video-extend-fast",
+  "wan2.2-spicy-video-extend",
+  "wan2.7-video-extend",
+  "pixverse-v6-extend",
+]);
+
+const KLING_EDIT_TOOL_IDS = new Set([
+  "kling-o1-video-edit",
+  "kling-o1-video-edit-fast",
+  "kling-o1-standard-video-edit",
+]);
+
+const VIDEO_TOOL_OVERRIDES = Object.create(null);
+
+for (const id of REQUIRED_EDIT_TOOL_IDS) {
+  VIDEO_TOOL_OVERRIDES[id] = {
+    hasPrompt: true,
+    promptRequired: true,
+    operation: "edit",
+  };
+}
+
+for (const id of REQUIRED_EXTEND_TOOL_IDS) {
+  VIDEO_TOOL_OVERRIDES[id] = {
+    hasPrompt: true,
+    promptRequired: true,
+    operation: "extend",
+  };
+}
+
+for (const id of KLING_EDIT_TOOL_IDS) {
+  VIDEO_TOOL_OVERRIDES[id] = {
+    ...VIDEO_TOOL_OVERRIDES[id],
+    payloadDefaults: { images_list: [] },
+  };
+}
+
+Object.assign(VIDEO_TOOL_OVERRIDES, {
+  "video-watermark-remover": {
+    hasPrompt: false,
+    operation: "watermark",
+  },
+  "ai-video-upscaler": {
+    hasPrompt: false,
+    operation: "upscale",
+    inputs: {
+      resolution: {
+        title: "Target resolution",
+        type: "string",
+        enum: ["720p", "1080p", "2k", "4k"],
+        default: "720p",
+        configurable: true,
+      },
+      copy_audio: {
+        title: "Keep audio",
+        type: "boolean",
+        default: true,
+        configurable: true,
+      },
+    },
+  },
+  "heygen-video-translate": {
+    hasPrompt: false,
+    operation: "translate",
+    summary:
+      "Translate the video's speech with synchronized voice and lip movement. The source language is detected automatically.",
+    inputs: {
+      language: {
+        title: "Target language",
+        type: "string",
+        enum: HEYGEN_TRANSLATION_LANGUAGES,
+        default: "Hindi",
+        configurable: true,
+      },
+    },
+  },
+  "topaz-video-upscale": {
+    hasPrompt: false,
+    operation: "upscale",
+    inputs: {
+      upscale_factor: {
+        title: "Upscale factor",
+        type: "integer",
+        enum: [1, 2, 4],
+        default: 2,
+        configurable: true,
+      },
+    },
+  },
+  "ltx-2.3-video-extend": {
+    hasPrompt: true,
+    promptRequired: false,
+    operation: "extend",
+    inputs: {
+      duration: {
+        title: "Extend duration",
+        type: "integer",
+        enum: Array.from({ length: 20 }, (_, index) => index + 1),
+        default: 5,
+        configurable: true,
+      },
+    },
+  },
+  "seedance-v2.0-extend": {
+    hasPrompt: true,
+    promptRequired: false,
+    operation: "extend",
+  },
+  "seedance-2-extend": {
+    hasPrompt: true,
+    promptRequired: false,
+    operation: "extend",
+  },
+  "seedance-2-vip-extend": {
+    hasPrompt: true,
+    promptRequired: false,
+    operation: "extend",
+  },
+  "seedance-2-vip-extend-1080p": {
+    hasPrompt: true,
+    promptRequired: false,
+    operation: "extend",
+  },
+  "veo3.1-extend-video": {
+    hasPrompt: true,
+    promptRequired: true,
+    operation: "extend",
+  },
+  "veo3.1-4k-video": {
+    hasPrompt: false,
+    promptRequired: false,
+    operation: "upscale",
+  },
+  "grok-imagine-extend": {
+    hasPrompt: true,
+    promptRequired: true,
+    operation: "extend",
+    inputs: {
+      extend_times: {
+        title: "Extend duration",
+        type: "integer",
+        enum: Array.from({ length: 25 }, (_, index) => index + 6),
+        default: 6,
+        configurable: true,
+      },
+    },
+  },
+});
+
+const ACTION_LABELS = Object.freeze({
+  edit: "Edit video",
+  extend: "Extend video",
+  process: "Process video",
+  translate: "Translate video",
+  upscale: "Upscale video",
+  watermark: "Remove watermark",
+});
+
+const PROMPT_LABELS = Object.freeze({
+  edit: "Describe how to edit the video",
+  extend: "Describe how to continue the video",
+  process: "Describe the result you want",
+});
+
+const CONTINUATION_FAMILIES = Object.freeze({
+  seedance: {
+    sourceModelIds: Object.freeze([
+      "seedance-v2.0-t2v",
+      "seedance-v2.0-i2v",
+      "seedance-v2.0-extend",
+      "seedance-2-extend",
+      "seedance-2-vip-extend",
+      "seedance-2-vip-extend-1080p",
+    ]),
+    sourceLabel: "Seedance 2.0 source video",
+    emptySourceMessage:
+      "Select a completed Seedance 2.0 video before continuing.",
+  },
+  veo31: {
+    sourceModelIds: Object.freeze([
+      "veo3.1-text-to-video",
+      "veo3.1-fast-text-to-video",
+      "veo3.1-lite-text-to-video",
+      "veo3.1-image-to-video",
+      "veo3.1-fast-image-to-video",
+      "veo3.1-lite-image-to-video",
+      "veo3.1-reference-to-video",
+      "veo3.1-extend-video",
+    ]),
+    sourceLabel: "Veo 3.1 source video",
+    emptySourceMessage:
+      "Select a completed Veo 3.1 video before running this operation.",
+  },
+  grok: {
+    sourceModelIds: Object.freeze([
+      "grok-imagine-text-to-video",
+      "grok-imagine-image-to-video",
+      "grok-imagine-extend",
+    ]),
+    sourceLabel: "Grok Imagine source video",
+    emptySourceMessage:
+      "Select a completed Grok Imagine video before extending it.",
+  },
+});
+
+const CONTINUATION_TARGETS = Object.freeze({
+  "seedance-v2.0-extend": { family: "seedance", promptRequired: false },
+  "seedance-2-extend": { family: "seedance", promptRequired: false },
+  "seedance-2-vip-extend": { family: "seedance", promptRequired: false },
+  "seedance-2-vip-extend-1080p": {
+    family: "seedance",
+    promptRequired: false,
+  },
+  "veo3.1-extend-video": { family: "veo31", promptRequired: true },
+  "veo3.1-4k-video": { family: "veo31", promptRequired: false },
+  "grok-imagine-extend": { family: "grok", promptRequired: true },
+});
+
+function mergeInputs(modelInputs = {}, overrideInputs = {}) {
+  const inputs = { ...modelInputs };
+  for (const [key, override] of Object.entries(overrideInputs)) {
+    inputs[key] = { ...modelInputs[key], ...override };
+  }
+  return inputs;
+}
+
+export function getVideoToolCapabilities(model) {
+  if (!model) return null;
+  const override = VIDEO_TOOL_OVERRIDES[model.id] || {};
+  return {
+    ...model,
+    ...override,
+    inputs: mergeInputs(model.inputs, override.inputs),
+  };
+}
+
+export function getVideoToolPresentation(model) {
+  const capabilities = getVideoToolCapabilities(model);
+  if (!capabilities) {
+    return {
+      actionLabel: ACTION_LABELS.process,
+      promptPlaceholder: PROMPT_LABELS.process,
+      promptRequired: false,
+      showPrompt: false,
+      summary: "Upload a source video to continue.",
+      uploadTitle: "Upload source video",
+    };
+  }
+
+  const showPrompt =
+    capabilities.hasPrompt ?? Boolean(capabilities.inputs?.prompt);
+  const promptRequired = showPrompt && Boolean(capabilities.promptRequired);
+  const operation = capabilities.operation || "process";
+  const promptLabel = PROMPT_LABELS[operation] || PROMPT_LABELS.process;
+
+  return {
+    actionLabel: ACTION_LABELS[operation] || ACTION_LABELS.process,
+    promptPlaceholder: promptRequired ? promptLabel : `${promptLabel} (optional)`,
+    promptRequired,
+    showPrompt,
+    summary:
+      capabilities.summary ||
+      capabilities.description ||
+      `${capabilities.name || "The selected tool"} is ready to process the video.`,
+    uploadTitle: `Upload source video for ${capabilities.name || "this tool"}`,
+  };
+}
+
+export function resolveVideoUploadTransition({
+  mode,
+  currentModel,
+  defaultModel,
+}) {
+  const preservesSelection =
+    (mode === "v2v" && Boolean(currentModel)) ||
+    Boolean(currentModel?.inputs?.video_files);
+
+  if (preservesSelection) {
+    return {
+      clearImage: false,
+      clearPrompt: false,
+      mode,
+      model: currentModel,
+    };
+  }
+
+  return {
+    clearImage: mode === "i2v",
+    clearPrompt: true,
+    mode: "v2v",
+    model: defaultModel,
+  };
+}
+
+export function getVideoToolOptionDefinitions(model) {
+  const capabilities = getVideoToolCapabilities(model);
+  if (!capabilities) return [];
+
+  return Object.entries(capabilities.inputs || {})
+    .filter(([, input]) => input.configurable)
+    .map(([key, input]) => ({ key, ...input }));
+}
+
+export function getDefaultVideoToolOptions(model) {
+  const options = {};
+  for (const input of getVideoToolOptionDefinitions(model)) {
+    if (input.default !== undefined) options[input.key] = input.default;
+  }
+  return options;
+}
+
+export function serializeVideoToolOptions(model, values = {}) {
+  const payload = {};
+  for (const input of getVideoToolOptionDefinitions(model)) {
+    const value = values[input.key];
+    if (value !== undefined) payload[input.key] = value;
+  }
+  return payload;
+}
+
+export function getVideoToolPayloadDefaults(model) {
+  const capabilities = getVideoToolCapabilities(model);
+  return { ...(capabilities?.payloadDefaults || {}) };
+}
+
+export function buildVideoToolPayload(model, params = {}) {
+  const capabilities = getVideoToolCapabilities(model);
+  const videoField = capabilities?.videoField || "video_url";
+  const payload = {
+    [videoField]: params.video_url,
+    ...getVideoToolPayloadDefaults(model),
+  };
+
+  if (capabilities?.imageField && params.image_url) {
+    payload[capabilities.imageField] = params.image_url;
+  }
+  if (capabilities?.hasPrompt && params.prompt) {
+    payload.prompt = params.prompt;
+  }
+
+  return {
+    ...payload,
+    ...serializeVideoToolOptions(model, params.options),
+  };
+}
+
+export function getContinuationConfig(modelOrId) {
+  const modelId = typeof modelOrId === "string" ? modelOrId : modelOrId?.id;
+  const target = CONTINUATION_TARGETS[modelId];
+  if (!target) return null;
+
+  return {
+    ...CONTINUATION_FAMILIES[target.family],
+    ...target,
+  };
+}
+
+export function getCompatibleContinuationSources(modelOrId, history = []) {
+  const config = getContinuationConfig(modelOrId);
+  if (!config) return [];
+  const compatibleModelIds = new Set(config.sourceModelIds);
+
+  return history.filter(
+    (entry) =>
+      Boolean(entry?.requestId && entry?.url) &&
+      compatibleModelIds.has(entry.model),
+  );
+}


### PR DESCRIPTION
## Changes

- Preserve the selected video tool and prompt across file-picker and drag-and-drop uploads.
- Add model-specific controls, validation, and actions for edit, extend, translate, and upscale workflows.
- Use compatible prior generations for continuation workflows while preserving provider request IDs.
- Build cost estimates and generation requests from the same payload.