### PR TITLE
fix(studio): enforce video model parameter constraints

### DIFF
--- a/packages/studio/src/components/VideoStudio.jsx
+++ b/packages/studio/src/components/VideoStudio.jsx
@@ -51,6 +51,22 @@ function getQualitiesForModel(modelList, modelId) {
   return model?.inputs?.quality?.enum || [];
 }
 
+function resolveSupportedValue(selectedValue, availableValues, fallbackValue) {
+  if (availableValues.includes(selectedValue)) return selectedValue;
+  if (availableValues.includes(fallbackValue)) return fallbackValue;
+  return availableValues[availableValues.length - 1];
+}
+
+function getVideoHistoryParameters(requestParams) {
+  const historyParams = {};
+  for (const field of ["aspect_ratio", "duration", "resolution"]) {
+    if (requestParams[field] !== undefined) {
+      historyParams[field] = requestParams[field];
+    }
+  }
+  return historyParams;
+}
+
 async function downloadFile(url, filename) {
   try {
     const response = await fetch(url);
@@ -582,9 +598,9 @@ export default function VideoStudio({
   const getCurrentResolutions = useCallback(
     (id) =>
       imageMode
-        ? getResolutionsForI2VModel(id)
-        : getResolutionsForVideoModel(id),
-    [imageMode],
+        ? getResolutionsForI2VModel(id, { duration: selectedDuration })
+        : getResolutionsForVideoModel(id, { duration: selectedDuration }),
+    [imageMode, selectedDuration],
   );
 
   const getCurrentModel = useCallback(
@@ -676,6 +692,25 @@ export default function VideoStudio({
     },
     [],
   );
+
+  useEffect(() => {
+    if (v2vMode) return;
+    const availableResolutions = imageMode
+      ? getResolutionsForI2VModel(selectedModel, { duration: selectedDuration })
+      : getResolutionsForVideoModel(selectedModel, { duration: selectedDuration });
+    if (
+      availableResolutions.length > 0 &&
+      !availableResolutions.includes(selectedResolution)
+    ) {
+      setSelectedResolution(availableResolutions[availableResolutions.length - 1]);
+    }
+  }, [
+    imageMode,
+    selectedDuration,
+    selectedModel,
+    selectedResolution,
+    v2vMode,
+  ]);
 
   // ── Persistence: Load ────────────────────────────────────────────────────
   useEffect(() => {
@@ -1162,6 +1197,10 @@ export default function VideoStudio({
           alert("Please upload a start frame image first.");
           return;
         }
+        if (currentModel?.endImageRequired && !uploadedEndImageUrl) {
+          alert("Please upload an end frame image first.");
+          return;
+        }
       }
     } else {
       if (!trimmedPrompt) {
@@ -1223,15 +1262,36 @@ export default function VideoStudio({
           i2vParams.image_url = uploadedImageUrl;
         }
         if (trimmedPrompt) i2vParams.prompt = trimmedPrompt;
-        i2vParams.aspect_ratio = selectedAr;
         const i2vModel = i2vModels.find((m) => m.id === selectedModel);
+        const aspectRatios = getAspectRatiosForI2VModel(selectedModel);
+        if (aspectRatios.length > 0) {
+          i2vParams.aspect_ratio = resolveSupportedValue(
+            selectedAr,
+            aspectRatios,
+            i2vModel?.inputs?.aspect_ratio?.default,
+          );
+        }
         if (uploadedEndImageUrl && i2vModel?.lastImageField) {
           i2vParams.last_image = uploadedEndImageUrl;
         }
         const durations = getDurationsForI2VModel(selectedModel);
-        if (durations.length > 0) i2vParams.duration = selectedDuration;
-        const resolutions = getResolutionsForI2VModel(selectedModel);
-        if (resolutions.length > 0) i2vParams.resolution = selectedResolution;
+        if (durations.length > 0) {
+          i2vParams.duration = resolveSupportedValue(
+            selectedDuration,
+            durations,
+            i2vModel?.inputs?.duration?.default,
+          );
+        }
+        const resolutions = getResolutionsForI2VModel(selectedModel, {
+          duration: i2vParams.duration,
+        });
+        if (resolutions.length > 0) {
+          i2vParams.resolution = resolveSupportedValue(
+            selectedResolution,
+            resolutions,
+            resolutions[resolutions.length - 1],
+          );
+        }
         if (selectedQuality) i2vParams.quality = selectedQuality;
         if (selectedMode) i2vParams.mode = selectedMode;
         if (showEffect && selectedEffect) i2vParams.name = selectedEffect;
@@ -1252,8 +1312,7 @@ export default function VideoStudio({
           url: res.url,
           prompt: trimmedPrompt,
           model: selectedModel,
-          aspect_ratio: selectedAr,
-          duration: selectedDuration,
+          ...getVideoHistoryParameters(i2vParams),
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1285,9 +1344,23 @@ export default function VideoStudio({
         }
 
         const durations = getDurationsForModel(selectedModel);
-        if (durations.length > 0) params.duration = selectedDuration;
-        const resolutions = getResolutionsForVideoModel(selectedModel);
-        if (resolutions.length > 0) params.resolution = selectedResolution;
+        if (durations.length > 0) {
+          params.duration = resolveSupportedValue(
+            selectedDuration,
+            durations,
+            currentModel?.inputs?.duration?.default,
+          );
+        }
+        const resolutions = getResolutionsForVideoModel(selectedModel, {
+          duration: params.duration,
+        });
+        if (resolutions.length > 0) {
+          params.resolution = resolveSupportedValue(
+            selectedResolution,
+            resolutions,
+            resolutions[resolutions.length - 1],
+          );
+        }
         if (selectedQuality) params.quality = selectedQuality;
         if (selectedMode) params.mode = selectedMode;
 
@@ -1310,8 +1383,7 @@ export default function VideoStudio({
           url: res.url,
           prompt: trimmedPrompt,
           model: selectedModel,
-          aspect_ratio: selectedAr,
-          duration: selectedDuration,
+          ...getVideoHistoryParameters(params),
           timestamp: new Date().toISOString(),
         };
         addToLocalHistory(entry);
@@ -1349,6 +1421,7 @@ export default function VideoStudio({
     showEffect,
     uploadedImageUrl,
     uploadedImageUrls,
+    uploadedEndImageUrl,
     uploadedVideoUrl,
     lastGenerationId,
     getCurrentModel,
@@ -1796,7 +1869,9 @@ export default function VideoStudio({
                   />
                   <button
                     type="button"
-                    title="Upload end frame (optional)"
+                    title={currentModelObj?.endImageRequired
+                      ? "Upload required end frame"
+                      : "Upload end frame (optional)"}
                     onClick={() => endImageFileInputRef.current?.click()}
                     className={promptMediaButtonClassName()}
                   >
@@ -1908,6 +1983,12 @@ export default function VideoStudio({
                 <path d="M5 12h14M12 5l7 7-7 7" />
               </svg>
               <span>Extending previous Seedance 2.0 generation</span>
+            </div>
+          )}
+
+          {currentModelObj?.parameterNotice && (
+            <div className="px-3 py-1.5 mx-3 bg-white/[0.03] border border-white/[0.06] rounded-lg text-[10px] text-white/55 font-medium tracking-tight">
+              {currentModelObj.parameterNotice}
             </div>
           )}
 

--- a/packages/studio/src/models.js
+++ b/packages/studio/src/models.js
@@ -4542,14 +4542,15 @@ export const t2vModels = [
         "default": "16:9"
       },
       "duration": {
+        "enum": [
+          5,
+          8
+        ],
         "title": "Duration",
         "name": "duration",
         "type": "int",
         "description": "The duration of the generated video in seconds. 8s not supported for 1080p resolution.",
-        "default": 5,
-        "minValue": 5,
-        "maxValue": 8,
-        "step": 3
+        "default": 5
       },
       "resolution": {
         "enum": [
@@ -4558,6 +4559,15 @@ export const t2vModels = [
           "720p",
           "1080p"
         ],
+        "enum_dependencies": {
+          "duration": {
+            "8": [
+              "360p",
+              "540p",
+              "720p"
+            ]
+          }
+        },
         "title": "Resolution",
         "name": "resolution",
         "type": "string",
@@ -4662,6 +4672,15 @@ export const t2vModels = [
           "720p",
           "1080p"
         ],
+        "enum_dependencies": {
+          "duration": {
+            "10": [
+              "360p",
+              "540p",
+              "720p"
+            ]
+          }
+        },
         "title": "Resolution",
         "name": "resolution",
         "type": "string",
@@ -4851,14 +4870,17 @@ export const t2vModels = [
       },
       "duration": {
         "enum": [
-          10,
-          15
+          4,
+          8,
+          12,
+          16,
+          20
         ],
         "title": "Duration",
         "name": "duration",
         "type": "int",
         "description": "The duration of the generated video in seconds",
-        "default": 10
+        "default": 8
       }
     },
     "provider": "openai",
@@ -4887,15 +4909,17 @@ export const t2vModels = [
       },
       "duration": {
         "enum": [
-          10,
-          15,
-          25
+          4,
+          8,
+          12,
+          16,
+          20
         ],
         "title": "Duration",
         "name": "duration",
         "type": "int",
-        "description": "The duration of the generated video in seconds. Currently 25 seconds supports 720p only.",
-        "default": 10
+        "description": "The duration of the generated video in seconds.",
+        "default": 8
       },
       "resolution": {
         "enum": [
@@ -7807,6 +7831,20 @@ export const t2vModels = [
 
 export const getVideoModelById = (id) => t2vModels.find(m => m.id === id);
 
+const getDependentEnumValues = (input, selections = {}) => {
+  const values = input?.enum || [];
+  const dependencies = input?.enum_dependencies;
+  if (!dependencies) return values;
+
+  return Object.entries(dependencies).reduce((available, [field, rules]) => {
+    const selectedValue = selections[field];
+    const allowedValues = rules?.[String(selectedValue)];
+    if (!allowedValues) return available;
+    const allowed = new Set(allowedValues);
+    return available.filter(value => allowed.has(value));
+  }, values);
+};
+
 export const getAspectRatiosForVideoModel = (modelId) => {
   const model = getVideoModelById(modelId);
   if (!model) return ['16:9'];
@@ -7824,11 +7862,11 @@ export const getDurationsForModel = (modelId) => {
   return [];
 };
 
-export const getResolutionsForVideoModel = (modelId) => {
+export const getResolutionsForVideoModel = (modelId, selections = {}) => {
   const model = getVideoModelById(modelId);
   if (!model) return [];
   const resInput = model.inputs?.resolution;
-  if (resInput && resInput.enum) return resInput.enum;
+  if (resInput?.enum) return getDependentEnumValues(resInput, selections);
   return [];
 };
 // Auto-generated from schema_data.json — Image to Image models
@@ -12055,6 +12093,15 @@ export const i2vModels = [
           "720p",
           "1080p"
         ],
+        "enum_dependencies": {
+          "duration": {
+            "8": [
+              "360p",
+              "540p",
+              "720p"
+            ]
+          }
+        },
         "default": "720p"
       },
       "duration": {
@@ -12062,10 +12109,11 @@ export const i2vModels = [
         "title": "Duration",
         "name": "duration",
         "description": "The duration of the generated video in seconds. 8s not supported for 1080p resolution.",
-        "default": 5,
-        "minValue": 5,
-        "maxValue": 8,
-        "step": 3
+        "enum": [
+          5,
+          8
+        ],
+        "default": 5
       }
     },
     "provider": "pixverse",
@@ -12715,10 +12763,13 @@ export const i2vModels = [
         "name": "duration",
         "description": "The duration of the generated video in seconds",
         "enum": [
-          10,
-          15
+          4,
+          8,
+          12,
+          16,
+          20
         ],
-        "default": 10
+        "default": 8
       },
       "remove_watermark": {
         "type": "boolean",
@@ -12784,13 +12835,15 @@ export const i2vModels = [
         "type": "int",
         "title": "Duration",
         "name": "duration",
-        "description": "The duration of the generated video in seconds. Currently 25 seconds supports 720p only.",
+        "description": "The duration of the generated video in seconds.",
         "enum": [
-          10,
-          15,
-          25
+          4,
+          8,
+          12,
+          16,
+          20
         ],
-        "default": 10
+        "default": 8
       },
       "resolution": {
         "type": "string",
@@ -13667,6 +13720,7 @@ export const i2vModels = [
     "family": "kling-v2.6",
     "imageField": "image_url",
     "hasPrompt": true,
+    "parameterNotice": "This integration supports 5 or 10 seconds.",
     "inputs": {
       "prompt": {
         "type": "string",
@@ -13769,6 +13823,15 @@ export const i2vModels = [
           "720p",
           "1080p"
         ],
+        "enum_dependencies": {
+          "duration": {
+            "10": [
+              "360p",
+              "540p",
+              "720p"
+            ]
+          }
+        },
         "default": "360p"
       },
       "duration": {
@@ -13985,6 +14048,8 @@ export const i2vModels = [
     "imageField": "image_url",
     "lastImageField": "last_image",
     "hasPrompt": true,
+    "aspectRatioMode": "inherited",
+    "parameterNotice": "Aspect ratio is inherited from the input image.",
     "inputs": {
       "prompt": {
         "type": "string",
@@ -14058,6 +14123,8 @@ export const i2vModels = [
     "imageField": "image_url",
     "lastImageField": "last_image",
     "hasPrompt": true,
+    "aspectRatioMode": "inherited",
+    "parameterNotice": "Aspect ratio is inherited from the input image.",
     "inputs": {
       "prompt": {
         "type": "string",
@@ -15030,7 +15097,10 @@ export const i2vModels = [
     "family": "pixverse-v6",
     "imageField": "image_url",
     "lastImageField": "last_image",
+    "endImageRequired": true,
     "hasPrompt": true,
+    "aspectRatioMode": "inherited",
+    "parameterNotice": "Start and end frames are required. Aspect ratio is determined by the input frames.",
     "inputs": {
       "prompt": {
         "type": "string",
@@ -15055,7 +15125,7 @@ export const i2vModels = [
         "type": "string",
         "title": "Ending Image",
         "name": "last_image",
-        "description": "Upload ending image (optional).",
+        "description": "Upload ending image.",
         "field": "image",
         "examples": [
           "https://d3adwkbyhxyrtq.cloudfront.net/webassets/videomodels/pixverse-v6-transition-1.jpg"
@@ -16986,7 +17056,6 @@ export const i2vModels = [
       },
       "resolution": {
         "enum": [
-          "360p",
           "540p",
           "720p",
           "1080p"
@@ -17608,6 +17677,8 @@ export const i2vModels = [
     "family": "video-generation",
     "imageField": "images_list",
     "hasPrompt": true,
+    "aspectRatioMode": "inherited",
+    "parameterNotice": "Aspect ratio is inherited from the input image.",
     "inputs": {
       "prompt": {
         "type": "string",
@@ -19435,6 +19506,7 @@ export const getAspectRatiosForI2IModel = (modelId) => {
 export const getAspectRatiosForI2VModel = (modelId) => {
     const model = getI2VModelById(modelId);
     if (!model) return ['16:9'];
+    if (model.aspectRatioMode === 'inherited') return [];
     if (model.inputs && model.inputs.aspect_ratio && model.inputs.aspect_ratio.enum) return model.inputs.aspect_ratio.enum;
     return ['16:9', '9:16', '1:1'];
 };
@@ -19454,11 +19526,11 @@ export const getDurationsForI2VModel = (modelId) => {
     return [];
 };
 
-export const getResolutionsForI2VModel = (modelId) => {
+export const getResolutionsForI2VModel = (modelId, selections = {}) => {
     const model = getI2VModelById(modelId);
     if (!model) return [];
     const res = model.inputs && model.inputs.resolution;
-    if (res && res.enum) return res.enum;
+    if (res?.enum) return getDependentEnumValues(res, selections);
     return [];
 };
 


### PR DESCRIPTION
- Enforce compatible duration and resolution combinations for Pixverse video models.
- Hide manual aspect ratio controls for image-driven models that inherit source dimensions.
- Require both frames for Pixverse transitions and remove the unsupported Vidu quality option.
- Align Sora duration presets and clarify Kling's integration-specific duration limit.
- Store only the video parameters actually sent to the API in generation history.