### PR TITLE
fix(studio): honor image model sizing contracts

### DIFF
--- a/packages/studio/src/components/ImageStudio.jsx
+++ b/packages/studio/src/components/ImageStudio.jsx
@@ -12,10 +12,10 @@ import MobileGenerationActions, {
 import {
   t2iModels,
   i2iModels,
-  getAspectRatiosForModel,
+  getSelectableAspectRatiosForModel as getAspectRatiosForModel,
   getResolutionsForModel,
   getQualityFieldForModel,
-  getAspectRatiosForI2IModel,
+  getSelectableAspectRatiosForI2IModel as getAspectRatiosForI2IModel,
   getResolutionsForI2IModel,
   getQualityFieldForI2IModel,
   getMaxImagesForI2IModel,
@@ -975,10 +975,20 @@ export default function ImageStudio({
       const stored = localStorage.getItem(PERSIST_KEY);
       if (stored) {
         const data = JSON.parse(stored);
-        if (data.imageMode !== undefined) setImageMode(data.imageMode);
-        if (data.selectedModelId) setSelectedModelId(data.selectedModelId);
-        if (data.selectedModelName) setSelectedModelName(data.selectedModelName);
-        if (data.selectedAr) setSelectedAr(data.selectedAr);
+        const restoredImageMode = data.imageMode === true;
+        const restoredModels = restoredImageMode ? i2iModels : t2iModels;
+        const restoredModel = restoredModels.find((model) => model.id === data.selectedModelId);
+        if (restoredModel) {
+          const ratios = restoredImageMode
+            ? getAspectRatiosForI2IModel(restoredModel.id)
+            : getAspectRatiosForModel(restoredModel.id);
+          setImageMode(restoredImageMode);
+          setSelectedModelId(restoredModel.id);
+          setSelectedModelName(restoredModel.name);
+          setSelectedAr(
+            ratios.includes(data.selectedAr) ? data.selectedAr : (ratios[0] || null),
+          );
+        }
         if (data.selectedQuality) setSelectedQuality(data.selectedQuality);
         if (data.selectedEffect) setSelectedEffect(data.selectedEffect);
         if (data.maxImages) setMaxImages(data.maxImages);
@@ -1147,7 +1157,7 @@ export default function ImageStudio({
         setImageMode(true);
         setSelectedModelId(target.id);
         setSelectedModelName(target.name);
-        setSelectedAr(ars[0] || "1:1");
+        setSelectedAr(ars[0] || null);
         setSelectedQuality(resolutions[0] || null);
         setSelectedEffect(effects.length > 0 ? (getDefaultEffectForI2IModel(target.id) || effects[0]) : "");
         setMaxImages(getMaxImagesForI2IModel(target.id));
@@ -1194,7 +1204,7 @@ export default function ImageStudio({
     const resolutions = getResolutionsForModel(target.id);
     setSelectedModelId(target.id);
     setSelectedModelName(target.name);
-    setSelectedAr(ars[0] || "1:1");
+    setSelectedAr(ars[0] || null);
     setSelectedQuality(resolutions[0] || null);
     setSelectedEffect("");
     setMaxImages(1);
@@ -1216,7 +1226,7 @@ export default function ImageStudio({
     setImageMode(nextImageMode);
     setSelectedModelId(m.id);
     setSelectedModelName(m.name);
-    setSelectedAr(ars[0] || "1:1");
+    setSelectedAr(ars[0] || null);
     setSelectedQuality(resolutions[0] || null);
     setSwapImageUrl(null);
     if (nextImageMode) {
@@ -1253,7 +1263,7 @@ export default function ImageStudio({
     const resolutions = getResolutionsForModel(firstT2I.id);
     setSelectedModelId(firstT2I.id);
     setSelectedModelName(firstT2I.name);
-    setSelectedAr(ars[0] || "1:1");
+    setSelectedAr(ars[0] || null);
     setSelectedQuality(resolutions[0] || null);
     setSelectedEffect("");
     setMaxImages(1);
@@ -1614,37 +1624,39 @@ export default function ImageStudio({
               </div>
 
               {/* Aspect ratio button */}
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDropdownOpen((o) => (o === "ar" ? null : "ar"));
-                  }}
-                  className={promptControlClassName({
-                    active: dropdownOpen === "ar",
-                  })}
-                >
-                  <PromptAspectRatioIcon />
-                  <span className={PROMPT_CONTROL_LABEL_CLASS}>
-                    {selectedAr}
-                  </span>
-                </button>
-
-                {dropdownOpen === "ar" && (
-                  <PromptPopover
-                    onClick={(e) => e.stopPropagation()}
+              {currentAspectRatios.length > 0 && (
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDropdownOpen((o) => (o === "ar" ? null : "ar"));
+                    }}
+                    className={promptControlClassName({
+                      active: dropdownOpen === "ar",
+                    })}
                   >
-                    <SimpleDropdown
-                      title="Aspect Ratio"
-                      options={currentAspectRatios}
-                      selected={selectedAr}
-                      onSelect={(val) => setSelectedAr(val)}
-                      onClose={() => setDropdownOpen(null)}
-                    />
-                  </PromptPopover>
-                )}
-              </div>
+                    <PromptAspectRatioIcon />
+                    <span className={PROMPT_CONTROL_LABEL_CLASS}>
+                      {selectedAr}
+                    </span>
+                  </button>
+
+                  {dropdownOpen === "ar" && (
+                    <PromptPopover
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <SimpleDropdown
+                        title="Aspect Ratio"
+                        options={currentAspectRatios}
+                        selected={selectedAr}
+                        onSelect={(val) => setSelectedAr(val)}
+                        onClose={() => setDropdownOpen(null)}
+                      />
+                    </PromptPopover>
+                  )}
+                </div>
+              )}
 
               {/* Quality/resolution button (represented as Diamond icon) */}
               {showQualityBtn && (

--- a/packages/studio/src/imageSizing.js
+++ b/packages/studio/src/imageSizing.js
@@ -1,0 +1,127 @@
+export const T2I_DIMENSION_RATIOS = Object.freeze([
+  '1:1',
+  '16:9',
+  '9:16',
+  '4:3',
+  '3:2',
+  '21:9',
+]);
+
+export const I2I_DIMENSION_RATIOS = Object.freeze([
+  '1:1',
+  '16:9',
+  '9:16',
+]);
+
+const gcd = (left, right) => {
+  let a = Math.abs(left);
+  let b = Math.abs(right);
+  while (b !== 0) {
+    [a, b] = [b, a % b];
+  }
+  return a;
+};
+
+const lcm = (left, right) => (left * right) / gcd(left, right);
+
+const parseAspectRatio = (aspectRatio) => {
+  const match = /^(\d+):(\d+)$/.exec(aspectRatio || '');
+  if (!match) return null;
+
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width === 0 || height === 0) {
+    return null;
+  }
+
+  const divisor = gcd(width, height);
+  return { width: width / divisor, height: height / divisor };
+};
+
+const isDimensionInput = (input) => {
+  const defaultValue = input?.default;
+  const minimum = input?.minValue;
+  const maximum = input?.maxValue;
+  const step = input?.step;
+
+  return Number.isSafeInteger(defaultValue) &&
+    Number.isSafeInteger(minimum) &&
+    Number.isSafeInteger(maximum) &&
+    Number.isSafeInteger(step) &&
+    minimum > 0 &&
+    step > 0 &&
+    minimum <= defaultValue &&
+    defaultValue <= maximum &&
+    minimum % step === 0;
+};
+
+export const getImageSizeCapability = (model) => {
+  const aspectRatio = model?.inputs?.aspect_ratio;
+  if (Array.isArray(aspectRatio?.enum) && aspectRatio.enum.length > 0) {
+    return { type: 'aspect_ratio', input: aspectRatio };
+  }
+
+  const width = model?.inputs?.width;
+  const height = model?.inputs?.height;
+  if (isDimensionInput(width) && isDimensionInput(height)) {
+    return { type: 'dimensions', width, height };
+  }
+
+  return { type: 'none' };
+};
+
+export const resolveImageDimensions = (model, aspectRatio) => {
+  const capability = getImageSizeCapability(model);
+  const ratio = parseAspectRatio(aspectRatio);
+  if (capability.type !== 'dimensions' || !ratio) return null;
+
+  const widthStep = capability.width.step;
+  const heightStep = capability.height.step;
+  const scaleStep = lcm(
+    widthStep / gcd(widthStep, ratio.width),
+    heightStep / gcd(heightStep, ratio.height),
+  );
+  const minimumScale = Math.ceil(Math.max(
+    capability.width.minValue / ratio.width,
+    capability.height.minValue / ratio.height,
+  ) / scaleStep) * scaleStep;
+  const maximumScale = Math.floor(Math.min(
+    capability.width.maxValue / ratio.width,
+    capability.height.maxValue / ratio.height,
+  ) / scaleStep) * scaleStep;
+
+  if (minimumScale > maximumScale) return null;
+
+  const defaultArea = capability.width.default * capability.height.default;
+  const targetScale = Math.sqrt(defaultArea / (ratio.width * ratio.height));
+  const nearestScale = Math.round(targetScale / scaleStep) * scaleStep;
+  const scale = Math.min(maximumScale, Math.max(minimumScale, nearestScale));
+
+  return {
+    width: ratio.width * scale,
+    height: ratio.height * scale,
+  };
+};
+
+export const getAspectRatioOptions = (model, dimensionRatios) => {
+  const capability = getImageSizeCapability(model);
+  if (capability.type === 'aspect_ratio') {
+    return capability.input.enum;
+  }
+
+  if (capability.type === 'dimensions') {
+    return dimensionRatios.filter((ratio) => resolveImageDimensions(model, ratio));
+  }
+
+  return [];
+};
+
+export const buildImageSizePayload = (model, aspectRatio) => {
+  const capability = getImageSizeCapability(model);
+  if (capability.type === 'aspect_ratio') {
+    return capability.input.enum.includes(aspectRatio) ? { aspect_ratio: aspectRatio } : {};
+  }
+
+  const dimensions = resolveImageDimensions(model, aspectRatio);
+  return dimensions || {};
+};

--- a/packages/studio/src/models.js
+++ b/packages/studio/src/models.js
@@ -1,4 +1,10 @@
 // Auto-generated from models_dump.json
+import {
+  getAspectRatioOptions,
+  I2I_DIMENSION_RATIOS,
+  T2I_DIMENSION_RATIOS,
+} from './imageSizing.js';
+
 export const t2iModels = [
   {
     "id": "nano-banana",
@@ -3338,15 +3344,17 @@ export const t2iModels = [
 
 export const getModelById = (id) => t2iModels.find(m => m.id === id);
 
+export const getSelectableAspectRatiosForModel = (modelId) => {
+  const model = getModelById(modelId);
+  return getAspectRatioOptions(model, T2I_DIMENSION_RATIOS);
+};
+
 export const getAspectRatiosForModel = (modelId) => {
   const model = getModelById(modelId);
   if (!model) return ['1:1'];
 
   const arInput = model.inputs?.aspect_ratio;
-  if (arInput && arInput.enum) {
-    return arInput.enum;
-  }
-
+  if (arInput && arInput.enum) return arInput.enum;
   return ['1:1', '16:9', '9:16', '4:3', '3:2', '21:9'];
 };
 
@@ -19423,6 +19431,11 @@ export const getMaxImagesForI2VModel = (modelId) => {
     if (imageInput?.type === 'array') return imageInput.maxItems || 1;
     if (model.lastImageField) return 2;
     return 1;
+};
+
+export const getSelectableAspectRatiosForI2IModel = (modelId) => {
+    const model = getI2IModelById(modelId);
+    return getAspectRatioOptions(model, I2I_DIMENSION_RATIOS);
 };
 
 export const getAspectRatiosForI2IModel = (modelId) => {

--- a/packages/studio/src/muapi.js
+++ b/packages/studio/src/muapi.js
@@ -1,4 +1,5 @@
 import { getModelById, getVideoModelById, getI2IModelById, getI2VModelById, getV2VModelById, getRecastModelById, getLipSyncModelById, getAudioModelById } from './models.js';
+import { buildImageSizePayload } from './imageSizing.js';
 
 // In an http(s) browser we route through the host app's proxy (Next.js routes
 // under /api/* re-issue the call server-side) so api.muapi.ai CORS is bypassed.
@@ -64,7 +65,8 @@ export async function generateImage(apiKey, params) {
     const modelInfo = getModelById(params.model);
     const endpoint = modelInfo?.endpoint || params.model;
     const payload = { prompt: params.prompt };
-    if (params.aspect_ratio) payload.aspect_ratio = params.aspect_ratio;
+    if (modelInfo) Object.assign(payload, buildImageSizePayload(modelInfo, params.aspect_ratio));
+    else if (params.aspect_ratio) payload.aspect_ratio = params.aspect_ratio;
     if (params.resolution) payload.resolution = params.resolution;
     if (params.quality) payload.quality = params.quality;
     if (params.image_url) { 
@@ -93,7 +95,8 @@ export async function generateI2I(apiKey, params) {
     if (modelInfo?.swapField && params.swap_url) {
         payload[modelInfo.swapField] = params.swap_url;
     }
-    if (params.aspect_ratio) payload.aspect_ratio = params.aspect_ratio;
+    if (modelInfo) Object.assign(payload, buildImageSizePayload(modelInfo, params.aspect_ratio));
+    else if (params.aspect_ratio) payload.aspect_ratio = params.aspect_ratio;
     if (params.resolution) payload.resolution = params.resolution;
     if (params.quality) payload.quality = params.quality;
     if (modelInfo?.inputs?.name) {
@@ -916,5 +919,4 @@ export async function expandImage(apiKey, { image_url, onRequestId }) {
     const payload = { image_url };
     return submitAndPoll(endpoint, payload, apiKey, onRequestId, 90);
 }
-
 


### PR DESCRIPTION
## Changes

- Preserve each image model’s native sizing contract.
- Map selected aspect ratios to schema-valid dimensions for width/height models.
- Hide unsupported size options and safely restore persisted model and ratio selections.