### PR TITLE
fix(video): add provider logos to model picker

### DIFF
--- a/src/components/VideoStudio.js
+++ b/src/components/VideoStudio.js
@@ -6,6 +6,7 @@ import { createUploadPicker } from './UploadPicker.js';
 import { savePendingJob, removePendingJob, getPendingJobs } from '../lib/pendingJobs.js';
 import { localAI, isLocalAIAvailable } from '../lib/localInferenceClient.js';
 import { isWan2gpModelId, getLocalModelById, localT2VModels, localI2VModels } from '../lib/localModels.js';
+import { createProviderFallbackTile, getProviderLogo, getProviderLogoAlt, getProviderFallbackText, handleProviderLogoError, shouldInvertProviderLogo } from '../lib/providerLogos.js';
 
 // Promotes a wan2gp catalog entry (lib/localModels.js shape) into the
 // `inputs`-shaped descriptor the Video Studio dropdowns/controls expect.
@@ -543,7 +544,7 @@ export function VideoStudio() {
             extendBanner.classList.remove('flex');
         }
     };
-
+    const failedProviderLogos = new Set();
     const showDropdown = (type, anchorBtn) => {
         dropdown.innerHTML = '';
         dropdown.classList.remove('opacity-0', 'pointer-events-none');
@@ -570,9 +571,19 @@ export function VideoStudio() {
                 const item = document.createElement('div');
                 item.className = `flex items-center justify-between p-3.5 hover:bg-white/5 rounded-2xl cursor-pointer transition-all border border-transparent hover:border-white/5 ${selectedModel === m.id ? 'bg-white/5 border-white/5' : ''}`;
                 const iconColor = isV2V ? 'bg-orange-500/10 text-orange-400' : m.id.includes('kling') ? 'bg-blue-500/10 text-blue-400' : m.id.includes('veo') ? 'bg-purple-500/10 text-purple-400' : m.id.includes('sora') ? 'bg-rose-500/10 text-rose-400' : 'bg-primary/10 text-primary';
+                const fallbackText = getProviderFallbackText(m);
+                const fallbackClasses = `w-10 h-10 ${iconColor} border border-white/5 rounded-xl flex items-center justify-center font-black text-sm shadow-inner uppercase`;
+                const fallbackMarkup = `<div data-provider-fallback class="${fallbackClasses}">${fallbackText}</div>`;
+                const configuredProviderLogo = getProviderLogo(m.provider);
+                const providerLogo = configuredProviderLogo && !failedProviderLogos.has(configuredProviderLogo)
+                    ? configuredProviderLogo
+                    : null;
+                const logoMarkup = providerLogo
+                    ? `<div class="w-10 h-10 rounded-xl border border-white/5 overflow-hidden shrink-0 flex items-center justify-center bg-white/[0.02]"><img data-provider-logo src="${providerLogo}" alt="${getProviderLogoAlt(m)}" loading="lazy" class="w-full h-full object-contain p-1 ${shouldInvertProviderLogo(m.provider) ? 'invert' : ''}"></div>`
+                    : fallbackMarkup;
                 item.innerHTML = `
                     <div class="flex items-center gap-3.5">
-                         <div class="w-10 h-10 ${iconColor} border border-white/5 rounded-xl flex items-center justify-center font-black text-sm shadow-inner uppercase">${m.name.charAt(0)}</div>
+                         ${logoMarkup}
                          <div class="flex flex-col gap-0.5">
                             <span class="text-xs font-bold text-white tracking-tight">${m.name}</span>
                             ${isV2V ? `<span class="text-[9px] text-orange-400/70">${m.imageField ? 'Upload a video and image' : 'Upload a video to use'}</span>` : ''}
@@ -580,6 +591,16 @@ export function VideoStudio() {
                     </div>
                     ${selectedModel === m.id ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="4"><polyline points="20 6 9 17 4 12"/></svg>' : ''}
                 `;
+                const logoImage = item.querySelector('[data-provider-logo]');
+                logoImage?.addEventListener('error', () => {
+                    const fallback = createProviderFallbackTile(document, fallbackClasses, fallbackText);
+                    handleProviderLogoError({
+                        image: logoImage,
+                        failedProviderLogos,
+                        providerLogo,
+                        fallback,
+                    });
+                }, { once: true });
                 item.onclick = (e) => {
                     e.stopPropagation();
                     if (isV2V) {

--- a/src/lib/providerLogos.js
+++ b/src/lib/providerLogos.js
@@ -1,0 +1,66 @@
+const PROVIDER_LOGOS = Object.freeze({
+    openai: 'https://cdn.muapi.ai/models/openai.png',
+    google: 'https://cdn.muapi.ai/models/gemini.png',
+    kling: 'https://cdn.muapi.ai/models/kling.png',
+    alibaba: 'https://cdn.muapi.ai/models/alibaba.png',
+    bytedance: 'https://cdn.muapi.ai/models/bytedance.png',
+    blackforest: 'https://cdn.muapi.ai/models/bfl.png',
+    minimax: 'https://cdn.muapi.ai/models/minimax.png',
+    suno: 'https://cdn.muapi.ai/models/suno.png',
+    anthropic: 'https://cdn.muapi.ai/models/claude.png',
+    meshy: 'https://cdn.muapi.ai/models/meshy-3.png',
+    tripo3d: 'https://cdn.muapi.ai/models/tripo3d.png',
+    grok: 'https://cdn.muapi.ai/models/xai.png',
+    muapi: 'https://cdn.muapi.ai/models/muapi.png',
+    midjourney: 'https://cdn.muapi.ai/models/midjourney.png',
+    vidu: 'https://cdn.muapi.ai/models/vidu.png',
+    runway: 'https://cdn.muapi.ai/models/runway.png',
+    luma: 'https://cdn.muapi.ai/models/luma.png',
+    ideogram: 'https://cdn.muapi.ai/models/ideogram.png',
+    leonardoai: 'https://cdn.muapi.ai/models/leonardoai.png',
+    hunyuan: 'https://cdn.muapi.ai/models/hunyuan.png',
+    hidream: 'https://cdn.muapi.ai/models/hidream.png',
+    lightricks: 'https://cdn.muapi.ai/models/lightricks.png',
+    pixverse: 'https://cdn.muapi.ai/models/pixverse.png',
+    reve: 'https://cdn.muapi.ai/models/reve.png',
+    stability: 'https://cdn.muapi.ai/models/stability.png',
+});
+
+const INVERTED_PROVIDER_LOGOS = new Set([
+    'openai',
+    'blackforest',
+    'runway',
+    'ideogram',
+    'lightricks',
+    'grok',
+]);
+
+const titleCaseProvider = (provider) => provider
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+export const getProviderLogo = (provider) => PROVIDER_LOGOS[provider] || null;
+
+export const getProviderLogoAlt = (model = {}) => {
+    if (model.provider_name) return model.provider_name;
+    if (model.provider) return titleCaseProvider(model.provider);
+    return 'AI provider';
+};
+
+export const getProviderFallbackText = (model = {}) => model.name?.trim()?.charAt(0)?.toUpperCase() || 'AI';
+export const createProviderFallbackTile = (documentRef, className, text) => {
+    const fallback = documentRef.createElement('div');
+    fallback.className = className;
+    fallback.dataset.providerFallback = '';
+    fallback.textContent = text;
+    return fallback;
+};
+
+export const handleProviderLogoError = ({ image, failedProviderLogos, providerLogo, fallback }) => {
+    if (!image?.parentElement) return false;
+    failedProviderLogos.add(providerLogo);
+    image.parentElement.replaceWith(fallback);
+    return true;
+};
+
+export const shouldInvertProviderLogo = (provider) => INVERTED_PROVIDER_LOGOS.has(provider);

--- a/tests/providerLogos.test.mjs
+++ b/tests/providerLogos.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    createProviderFallbackTile,
+    getProviderLogo,
+    getProviderLogoAlt,
+    getProviderFallbackText,
+    handleProviderLogoError,
+    shouldInvertProviderLogo,
+} from '../src/lib/providerLogos.js';
+
+test('maps canonical video providers to logos and accessible labels', () => {
+    assert.equal(getProviderLogo('google'), 'https://cdn.muapi.ai/models/gemini.png');
+    assert.equal(getProviderLogoAlt({ provider: 'google', provider_name: 'Google' }), 'Google');
+    assert.equal(shouldInvertProviderLogo('google'), false);
+});
+
+test('uses initials for unmapped or missing providers', () => {
+    assert.equal(getProviderLogo('unknown-provider'), null);
+    assert.equal(getProviderLogoAlt({ provider: 'unknown-provider' }), 'Unknown Provider');
+    assert.equal(getProviderFallbackText({ name: 'Hunyuan Video' }), 'H');
+    assert.equal(getProviderFallbackText({}), 'AI');
+});
+
+test('preserves canonical inverted-logo behavior', () => {
+    assert.equal(shouldInvertProviderLogo('openai'), true);
+    assert.equal(shouldInvertProviderLogo('runway'), true);
+    assert.equal(shouldInvertProviderLogo('kling'), false);
+});
+
+test('replaces a failed logo and ignores detached image callbacks', () => {
+    const documentStub = {
+        createElement() {
+            return { dataset: {}, className: '', textContent: '' };
+        },
+    };
+    const fallback = createProviderFallbackTile(documentStub, 'fallback', 'G');
+    const failedProviderLogos = new Set();
+    const replacementParent = {
+        replaceWith(node) {
+            this.replacement = node;
+        },
+    };
+    const image = { parentElement: replacementParent };
+
+    assert.equal(handleProviderLogoError({
+        image,
+        failedProviderLogos,
+        providerLogo: 'https://cdn.muapi.ai/models/gemini.png',
+        fallback,
+    }), true);
+    assert.equal(failedProviderLogos.has('https://cdn.muapi.ai/models/gemini.png'), true);
+    assert.equal(replacementParent.replacement, fallback);
+
+    assert.equal(handleProviderLogoError({
+        image: { parentElement: null },
+        failedProviderLogos,
+        providerLogo: 'https://cdn.muapi.ai/models/gemini.png',
+        fallback,
+    }), false);
+});


### PR DESCRIPTION
## Summary

The standalone Video Studio model picker now shows provider logos instead of model-name initials where provider branding is available. Unmapped providers and failed logo loads keep the existing initials fallback, so model discovery remains usable without relying on every logo request succeeding.

## Changes

- Reuse the canonical provider logo mapping and accessibility labels already used by the shared studio implementation.
- Lazy-load provider images and cache failed provider URLs to avoid repeated failed requests during picker rerenders.
- Guard stale image-error callbacks after search or mode rerenders.
- Add focused coverage for provider mapping, initials fallback, inversion rules, and detached-image error handling.

## Validation

- `node --test tests/*.test.js tests/providerLogos.test.mjs` — 21 tests passed.
- `npm run vite:build` — production Vite build passed.
- Browser smoke on the standalone app: Video Studio opened, provider logo DOM and alt text observed, model search filtered to Kling entries, model selection updated the active model, failed-logo fallback was exercised, stale callback rerender path completed without errors, and the console contained no errors.

Fixes #303
